### PR TITLE
Feature/change user groups script

### DIFF
--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -60,7 +60,7 @@ def main():
                 if args.remove_ous and element.get('organisationUnits'):
                     element['organisationUnits'] = []
                 if args.remove_catcombos and element.get('categoryCombo'):
-                    element['categoryCombo'] = []
+                    del element['categoryCombo']
 
             if args.replace_ids and element['id'] in replacements.keys():
                 element['id'] = replacements.get(element['id'])

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -1,5 +1,11 @@
 #/usr/bin/env python3
+
+"""
+Change sharing settings on a json file
+"""
+
 import json
+import argparse
 
 dhis_objects = [
     "indicators",
@@ -16,20 +22,42 @@ dhis_objects = [
     "trackedEntityTypes"
 ]
 
-for dhis_object in dhis_objects:
-    dhis_object_old = json.load(open('input.json')).get(dhis_object)
 
-    if not dhis_object_old:
-        continue
+def main():
+    args = get_args()
 
-    userGroupAccesses_new = json.load(open('userGroupAccesses.json'))['userGroupAccesses']
+    dhis_objects = [item for item in args.include if item not in args.exclude]
+    output = {}
+
+    for dhis_object in dhis_objects:
+        dhis_object_old = json.load(open('input.json')).get(dhis_object)
+
+        if not dhis_object_old:
+            print('WARN: Ignoring not found object %s' % dhis_object)
+            continue
+
+        userGroupAccesses_new = json.load(open('userGroupAccesses.json'))['userGroupAccesses']
+
+        elements_new = []
+        for element in dhis_object_old:
+            # Remove public access
+            element['publicAccess'] = args.public_access
+            element['userGroupAccesses'] = userGroupAccesses_new
+            elements_new.append(element)
+
+        output[dhis_object] = elements_new
+
+    json.dump(output, open('output.json', 'wt'), indent=2)
 
 
-    elements_new = []
-    for element in dhis_object_old:
-        # Remove public access
-        element['publicAccess'] = '--------'
-        element['userGroupAccesses'] = userGroupAccesses_new
-        elements_new.append(element)
+def get_args():
+    "Return arguments"
+    parser = argparse.ArgumentParser(description=__doc__)
+    add = parser.add_argument  # shortcut
+    add('--public-access', default='--------', help='set public permissions. Default: no public access (--------)')
+    add('--include', nargs='+', default=dhis_objects, help='DHIS2 objects to include. Default: All')
+    add('--exclude', nargs='+', default=[], help='DHIS2 objects to exclude. Default: None')
+    return parser.parse_args()
 
-    json.dump({dhis_object: elements_new}, open('results/%s.json' % dhis_object, 'wt'), indent=2)
+if __name__ == '__main__':
+    main()

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -6,28 +6,41 @@ Change sharing settings on a json file
 
 import json
 import argparse
+import sys
 
 dhis_objects = [
     "indicators",
     "indicatorGroups",
     "programIndicators",
-    "options",
-    "programRuleVariables",
     "programIndicators",
     "optionSets",
     "dataElements",
+    "programs",
     "programStages",
     "programStageSections",
     "legendSets",
-    "trackedEntityTypes"
+    "trackedEntityTypes",
+    "trackedEntityAttributes",
+    "categories",
+    "categoryCombos",
+    "categoryOptionCombos",
+    "categoryOptions"
 ]
 
 
 def main():
     args = get_args()
-
     dhis_objects = [item for item in args.include if item not in args.exclude]
     output = {}
+    replacements = {}
+
+    if args.replace_ids:
+        n = len(args.replace_ids)
+        if n%2!=0:
+            sys.exit('Error: uneven number of ids to replace (%d), but ids should come '
+                     'in pairs (from, to)' % n)
+        else:
+            replacements = dict([(args.replace_ids[2 * i], args.replace_ids[2 * i + 1]) for i in range(n // 2)])
 
     for dhis_object in dhis_objects:
         dhis_object_old = json.load(open('input.json')).get(dhis_object)
@@ -40,21 +53,29 @@ def main():
 
         elements_new = []
         for element in dhis_object_old:
-            # Remove public access
             element['publicAccess'] = args.public_access
             element['userGroupAccesses'] = userGroupAccesses_new
+
+            if args.remove_ous and dhis_object == 'program':
+                element['organisationUnits'] = []
+
+            if args.replace_ids and element['id'] in replacements.keys():
+                element['id'] = replacements.get(element['id'])
+
             elements_new.append(element)
 
         output[dhis_object] = elements_new
 
     json.dump(output, open('output.json', 'wt'), indent=2)
 
-
 def get_args():
     "Return arguments"
     parser = argparse.ArgumentParser(description=__doc__)
     add = parser.add_argument  # shortcut
     add('--public-access', default='--------', help='set public permissions. Default: no public access (--------)')
+    add('--remove-ous', action='store_true', help='remove ous assignment from programs')
+    add('--replace-ids', nargs='+', metavar='FROM TO', default=[],
+        help='ids to replace. NOTE: references are not updated!!!')
     add('--include', nargs='+', default=dhis_objects, help='DHIS2 objects to include. Default: All')
     add('--exclude', nargs='+', default=[], help='DHIS2 objects to exclude. Default: None')
     return parser.parse_args()

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -1,0 +1,35 @@
+#/usr/bin/env python3
+import json
+
+dhis_objects = [
+    "indicators",
+    "indicatorGroups",
+    "programIndicators",
+    "options",
+    "programRuleVariables",
+    "programIndicators",
+    "optionSets",
+    "dataElements",
+    "programStages",
+    "programStageSections",
+    "legendSets",
+    "trackedEntityTypes"
+]
+
+for dhis_object in dhis_objects:
+    dhis_object_old = json.load(open('input.json')).get(dhis_object)
+
+    if not dhis_object_old:
+        continue
+
+    userGroupAccesses_new = json.load(open('userGroupAccesses.json'))['userGroupAccesses']
+
+
+    elements_new = []
+    for element in dhis_object_old:
+        # Remove public access
+        element['publicAccess'] = '--------'
+        element['userGroupAccesses'] = userGroupAccesses_new
+        elements_new.append(element)
+
+    json.dump({dhis_object: elements_new}, open('results/%s.json' % dhis_object, 'wt'), indent=2)

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -56,8 +56,11 @@ def main():
             element['publicAccess'] = args.public_access
             element['userGroupAccesses'] = userGroupAccesses_new
 
-            if args.remove_ous and dhis_object == 'program':
-                element['organisationUnits'] = []
+            if dhis_object in ['programs', 'dataElements']:
+                if args.remove_ous and element.get('organisationUnits'):
+                    element['organisationUnits'] = []
+                if args.remove_catcombos and element.get('categoryCombo'):
+                    element['categoryCombo'] = []
 
             if args.replace_ids and element['id'] in replacements.keys():
                 element['id'] = replacements.get(element['id'])
@@ -74,6 +77,7 @@ def get_args():
     add = parser.add_argument  # shortcut
     add('--public-access', default='--------', help='set public permissions. Default: no public access (--------)')
     add('--remove-ous', action='store_true', help='remove ous assignment from programs')
+    add('--remove-catcombos', action='store_true', help='remove catcombos assignment from programs')
     add('--replace-ids', nargs='+', metavar='FROM TO', default=[],
         help='ids to replace. NOTE: references are not updated!!!')
     add('--include', nargs='+', default=dhis_objects, help='DHIS2 objects to include. Default: All')

--- a/DHIS2/metadata_manipulation/userGroupAccesses.json
+++ b/DHIS2/metadata_manipulation/userGroupAccesses.json
@@ -1,0 +1,34 @@
+{
+    "userGroupAccesses": [
+        {
+        "access": "rwr-----",
+        "userGroupUid": "Urx6COfeLkm",
+        "displayName": "ETA administrators",
+        "id": "Urx6COfeLkm"
+        },
+        {
+        "access": "r-r-----",
+        "userGroupUid": "GjnWefzEY20",
+        "displayName": "ETA Data Entry",
+        "id": "GjnWefzEY20"
+        },
+        {
+        "access": "r-r-----",
+        "userGroupUid": "uNJOBaIvuNw",
+        "displayName": "ETA Facility Analysis Only",
+        "id": "uNJOBaIvuNw"
+        },
+        {
+        "access": "r-r-----",
+        "userGroupUid": "y4eVE0uT9yz",
+        "displayName": "ETA Users",
+        "id": "y4eVE0uT9yz"
+        },
+        {
+        "access": "r-r-----",
+        "userGroupUid": "QhhxtdJ8HL7",
+        "displayName": "ETA Ministry Analysis Only",
+        "id": "QhhxtdJ8HL7"
+        }
+    ]
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #36
* **Related pull-requests:**

### :tophat: What is the goal?

Sharing settings App was failing in 2.30 and we needed to migrate a program changing the sharing settings in the middle. Instead of manually doing it, it was better to create a script that can be useful in the future.

### :memo: How is it being implemented?

I used the same structure of the cloning script. In a nutshell:
- The argsparse library to get the arguments
- A static list of DHIS2 objects whose userGroups and publicAccess parameters will be modified
- An auxiliar userGroupAccesses.json file. This file will be placed in every object that will be modified
- A main function that first process the arguments and then just apply the sharing changes to all the objects that are in the default objects array unless another one is provided, and that are not in the array of objects to avoid, unless another one is provided.

Please note that the replace-ids argument is not yet fully functional because it changes the IDs on the top-level element but it doesn't change any reference to them at any other level of the hierarchy

### :boom: How can it be tested?
Get a json file from the metadata export of DHIS2, build a userGroupAccesses.json file with a different sharings settings configuration and...

 **Use case 1:** Apply the change without parameters and check the output has been applied to every DHIS2 object blocking public access
 **Use case 2:** Apply the change removing OUs and check that there's no OUs assignment under program (if you discover any other OU reference please note that in the review)
 **Use case 3:** Apply the change excluding and including objects to check that only included and not excluded objects are altered
 **Use case 4:** Apply the change removing any category/catcombo/cat option/cat option combo reference and check it's been applied

### :floppy_disk: Requires DB migration?

- [x] Nope, we can just merge this branch.
- [ ] Yes, but we need to apply it before merging this branch.
- [ ] Yes, it's already applied.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-