### PR TITLE
Feature/clone from url

### DIFF
--- a/DHIS2/cloner/configuration_example.json
+++ b/DHIS2/cloner/configuration_example.json
@@ -15,13 +15,27 @@
     },
     "postprocess": [
         {
-            "usernames": ["guest", "clone_test_user"]
+            "selectUsernames": ["guest"],
+            "selectFromGroups": ["program1", "program2"],
+            "action": "activate"
         },
         {
-            "usernames": ["test.dataentry"],
-            "fromGroups": ["program1", "program2"],
-            "addRoles": ["role1", "role2"],
+            "selectUsernames": ["guest"],
+            "selectFromGroups": ["program1", "program2"],
+            "action": "deleteOthers"
+        },
+        {
+            "selectUsernames": ["guest"],
+            "selectFromGroups": ["program1", "program2"],
+            "action": "addRoles",
+            "addRoles": ["role1", "role2"]
+        },
+        {
+            "selectUsernames": ["guest"],
+            "selectFromGroups": ["program1", "program2"],
+            "action": "addRolesFromTemplate",
             "addRolesFromTemplate": "validator.template"
         }
-    ]
+    ],
+    "postprocess_url": "https://raw.githubusercontent.com/EyeSeeTea/ESTools/master/DHIS2/cloner/configuration_example_only_postprocess.json"
 }

--- a/DHIS2/cloner/configuration_example.json
+++ b/DHIS2/cloner/configuration_example.json
@@ -16,25 +16,22 @@
     "postprocess": [
         {
             "selectUsernames": ["guest"],
-            "selectFromGroups": ["program1", "program2"],
             "action": "activate"
         },
         {
-            "selectUsernames": ["guest"],
-            "selectFromGroups": ["program1", "program2"],
+            "selectUsernames": ["admin", "guest"],
+            "selectFromGroups": ["program1"],
             "action": "deleteOthers"
         },
         {
-            "selectUsernames": ["guest"],
             "selectFromGroups": ["program1", "program2"],
             "action": "addRoles",
             "addRoles": ["role1", "role2"]
         },
         {
-            "selectUsernames": ["guest"],
-            "selectFromGroups": ["program1", "program2"],
+            "selectUsernames": ["teacher1", "teacher2"],
             "action": "addRolesFromTemplate",
-            "addRolesFromTemplate": "validator.template"
+            "addRolesFromTemplate": "teacher.template"
         },
         "https://raw.githubusercontent.com/EyeSeeTea/ESTools/master/DHIS2/cloner/configuration_example_only_postprocess.json"
     ]

--- a/DHIS2/cloner/configuration_example.json
+++ b/DHIS2/cloner/configuration_example.json
@@ -35,7 +35,7 @@
             "selectFromGroups": ["program1", "program2"],
             "action": "addRolesFromTemplate",
             "addRolesFromTemplate": "validator.template"
-        }
-    ],
-    "postprocess_url": "https://raw.githubusercontent.com/EyeSeeTea/ESTools/master/DHIS2/cloner/configuration_example_only_postprocess.json"
+        },
+        "https://raw.githubusercontent.com/EyeSeeTea/ESTools/master/DHIS2/cloner/configuration_example_only_postprocess.json"
+    ]
 }

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -61,12 +61,8 @@ def main():
         start_tomcat(dir_local)
         if args.no_postprocess:
             log('No postprocessing done, as requested.')
-        elif 'api_local' in cfg:
-            if 'postprocess' in cfg:
-                process.postprocess(cfg['api_local'], cfg['postprocess'])
-            if 'postprocess_url' in cfg:
-                posprocess.postprocess_url(cfg['api_local'],
-                                           cfg['postprocess_url'])
+        elif 'api_local' in cfg and 'postprocess' in cfg:
+            process.postprocess(cfg['api_local'], cfg['postprocess'])
         else:
             log('No postprocessing done.')
     else:

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -26,7 +26,7 @@ def main():
     if args.no_color or not os.isatty(sys.stdout.fileno()):
         COLOR = False
 
-    cfg = get_config(args.config)
+    cfg = get_config(args.config, args.update_config)
     if args.check_only:
         sys.exit()
     elif args.update_config:
@@ -74,18 +74,6 @@ def main():
         log('No postprocessing done.')
 
 
-def get_config(fname):
-    "Return dict with the options read from configuration file"
-    log('Reading from config file %s ...' % fname)
-    try:
-        with open(fname) as f:
-            config = json.load(f)
-        check_config(config)
-    except (AssertionError, IOError, ValueError) as e:
-        sys.exit('Error reading config file %s: %s' % (fname, e))
-    return config
-
-
 def get_args():
     "Return arguments"
     parser = argparse.ArgumentParser(description=__doc__)
@@ -105,18 +93,37 @@ def get_args():
     return parser.parse_args()
 
 
+def get_config(fname, update):
+    "Return dict with the options read from configuration file"
+    log('Reading from config file %s ...' % fname)
+    try:
+        with open(fname) as f:
+            config = json.load(f)
+        if get_version(config) != 2:
+            if update:
+                update_config(fname)
+                sys.exit()
+            else:
+                raise ValueError('Old version of configuration file. Run with '
+                                 '--update-config to upgrade.')
+        check_config(config)
+    except (AssertionError, IOError, ValueError) as e:
+        sys.exit('Error reading config file %s: %s' % (fname, e))
+    return config
+
+
 def check_config(cfg):
     "Assert all the options in configuration exist and have reasonable values"
     for option in ['backups_dir', 'backup_name', 'hostname_remote',
                    'server_dir_local', 'server_dir_remote',
                    'db_local', 'db_remote', 'war_local', 'war_remote']:
         assert option in cfg, 'Missing option "%s"' % option
+
     if 'api_local' not in cfg:
         log('Option api_local missing. Will not do any postprocessing.')
     elif 'postprocess' not in cfg:
         log('Option postprocess missing. Will not do local postprocessing.')
-    elif 'postprocess_url' not in cfg:
-        log('Option postprocess_url missing. Will not read from remote url.')
+
     for path in ['backups_dir', 'server_dir_local', 'post_clone_scripts_dir']:
         if cfg.has_key(path):
             assert os.path.isdir(cfg[path]), \
@@ -130,6 +137,7 @@ def check_config(cfg):
     for war in ['war_local', 'war_remote']:
         assert cfg[war].endswith('.war'), \
             'war file does not end with .war: %s' % cfg[war]
+    log('Configuration looks OK.')
 
 
 def update_config(fname):
@@ -142,12 +150,14 @@ def update_config(fname):
     else:
         if 'postprocess' in config:
             entries = []
-            for entry_old in config['postprocess']:
+            for entry in config['postprocess']:
                 entries += update_entry(entry)
             config['postprocess'] = entries
         name, ext = os.path.splitext(fname)
-        with open(name + '_updated' + ext, 'wt') as fnew:
-            json.dump(config, fnew)
+        fname_new = name + '_updated' + ext
+        log('Writing updated configuration in %s' % fname_new)
+        with open(fname_new, 'wt') as fnew:
+            json.dump(config, fnew, indent=2)
 
 
 def update_entry(entry_old):
@@ -181,14 +191,14 @@ def update_entry(entry_old):
 
 def get_version(config):
     "Return the highest version for which the given configuration is valid"
-    if 'postprocess' not in config:
+    if 'postprocess' not in config or not config['postprocess']:
         return 2
     for entry in config['postprocess']:
         if 'usernames' in entry or 'fromGroups' in entry:
             return 1
         if 'selectUsernames' in entry or 'selectFromGroups' in entry:
             return 2
-    raise RuntimeException('Unknown version of configuration file.'
+    raise ValueError('Unknown version of configuration file.')
 
 
 def is_good_db_uri(uri):

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -58,8 +58,12 @@ def main():
         start_tomcat(dir_local)
         if args.no_postprocess:
             log('No postprocessing done, as requested.')
-        elif 'api_local' in cfg and 'postprocess' in cfg:
-            process.postprocess(cfg['api_local'], cfg['postprocess'])
+        elif 'api_local' in cfg:
+            if 'postprocess' in cfg:
+                process.postprocess(cfg['api_local'], cfg['postprocess'])
+            if 'postprocess_url' in cfg:
+                posprocess.postprocess_url(cfg['api_local'],
+                                           cfg['postprocess_url'])
         else:
             log('No postprocessing done.')
     else:
@@ -103,9 +107,12 @@ def check_config(cfg):
                    'server_dir_local', 'server_dir_remote',
                    'db_local', 'db_remote', 'war_local', 'war_remote']:
         assert option in cfg, 'Missing option "%s"' % option
-    for option in ['api_local', 'postprocess']:
-        if option not in cfg:
-            log('Option %s missing. Will not do postprocessing.' % option)
+    if 'api_local' not in cfg:
+        log('Option api_local missing. Will not do any postprocessing.')
+    elif 'postprocess' not in cfg:
+        log('Option postprocess missing. Will not do local postprocessing.')
+    elif 'postprocess_url' not in cfg:
+        log('Option postprocess_url missing. Will not read from remote url.')
     for path in ['backups_dir', 'server_dir_local', 'post_clone_scripts_dir']:
         if cfg.has_key(path):
             assert os.path.isdir(cfg[path]), \

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -29,6 +29,9 @@ def main():
     cfg = get_config(args.config)
     if args.check_only:
         sys.exit()
+    elif args.update_config:
+        update_config(args.config)
+        sys.exit()
 
     dir_local, dir_remote = cfg['server_dir_local'], cfg['server_dir_remote']
     db_local, db_remote = cfg['db_local'], cfg['db_remote']
@@ -96,7 +99,8 @@ def get_args():
     add('--manual-restart', action='store_true', help="don't stop/start tomcat")
     add('--post-sql', nargs='+', default=[], help='sql files to run post-clone')
     add('--post-clone-scripts', action='store_true',
-        help='execute all py and sh scripts in the post_clone_scripts_dir folder')
+        help='execute all py and sh scripts in post_clone_scripts_dir')
+    add('--update-config', action='store_true', help='update the config file')
     add('--no-color', action='store_true', help="don't use colored output")
     return parser.parse_args()
 
@@ -126,6 +130,65 @@ def check_config(cfg):
     for war in ['war_local', 'war_remote']:
         assert cfg[war].endswith('.war'), \
             'war file does not end with .war: %s' % cfg[war]
+
+
+def update_config(fname):
+    "Update the configuration file from an old format to the current one"
+    with open(fname) as f:
+        config = json.load(f)
+
+    if get_version(config) == 2:
+        log('The current configuration file is valid. Nothing to update.')
+    else:
+        if 'postprocess' in config:
+            entries = []
+            for entry_old in config['postprocess']:
+                entries += update_entry(entry)
+            config['postprocess'] = entries
+        name, ext = os.path.splitext(fname)
+        with open(name + '_updated' + ext, 'wt') as fnew:
+            json.dump(config, fnew)
+
+
+def update_entry(entry_old):
+    "Return a list of dictionaries that correspond to the actions in entry"
+    entries = []
+
+    # Get the selected users part.
+    users = {}
+    if 'usernames' in entry_old:
+        users['selectUsernames'] = entry_old['usernames']
+    if 'fromGroups' in entry_old:
+        users['selectFromGroups'] = entry_old['fromGroups']
+
+    # Add a new entry for each action described in the old entry.
+    old_actions = ['addRoles', 'addRolesFromTemplate']
+    if all(action not in entry_old for action in old_actions):
+        entry_new = users.copy()
+        entry_new['action'] = 'activate'
+        entries.append(entry_new)
+    else:
+        for action in old_actions:
+            if action in entry_old:
+                entry_new = users.copy()
+                entry_new['action'] = action
+                entry_new[action] = entry_old[action]
+                entries.append(entry_new)
+
+    return entries
+
+
+
+def get_version(config):
+    "Return the highest version for which the given configuration is valid"
+    if 'postprocess' not in config:
+        return 2
+    for entry in config['postprocess']:
+        if 'usernames' in entry or 'fromGroups' in entry:
+            return 1
+        if 'selectUsernames' in entry or 'selectFromGroups' in entry:
+            return 2
+    raise RuntimeException('Unknown version of configuration file.'
 
 
 def is_good_db_uri(uri):

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -88,7 +88,7 @@ def get_args():
     add('--no-backups', action='store_true', help="don't make backups")
     add('--no-webapps', action='store_true', help="don't clone the webapps")
     add('--no-db', action='store_true', help="don't clone the database")
-    add('--no-postprocess', action='store_true', help="don't execute postprocessing actions")
+    add('--no-postprocess', action='store_true', help="don't do postprocessing")
     add('--manual-restart', action='store_true', help="don't stop/start tomcat")
     add('--post-sql', nargs='+', default=[], help='sql files to run post-clone')
     add('--post-clone-scripts', action='store_true',
@@ -142,17 +142,10 @@ def magenta(txt):
     return '\x1b[35m%s\x1b[0m' % txt
 
 
-def execute_scripts(scripts_folder):
-    scripts = []
-    files = os.listdir(scripts_folder)
-    for fname in files:
-        _, ext = os.path.splitext(fname)
-        if ext in ['.sh','.py']:
-            scripts.append(fname)
-
-    for script in sorted(scripts):
-        command = '%s/%s' % (scripts_folder, script)
-        run(command)
+def execute_scripts(dirname):
+    is_script = lambda fname: os.path.splitext(fname)[-1] in ['.sh', '.py']
+    for script in sorted(filter(is_script, os.listdir(dirname))):
+        run('"%s/%s"' % (dirname, script))
 
 
 def start_tomcat(server_path):

--- a/DHIS2/cloner/dhis2api.py
+++ b/DHIS2/cloner/dhis2api.py
@@ -14,6 +14,7 @@ class Dhis2Api:
         >> api.patch('/users/3', ...)
     """
     def __init__(self, url, username='admin', password='district'):
+        self.username = username
         self.api_url = url.rstrip('/') + '/api'
         self.auth = requests.auth.HTTPBasicAuth(username, password)
 

--- a/DHIS2/cloner/dhis2api.py
+++ b/DHIS2/cloner/dhis2api.py
@@ -38,3 +38,6 @@ class Dhis2Api:
 
     def patch(self, path, payload):
         return self._request('patch', path, json=payload)
+
+    def delete(self, path):
+        return self._request('delete', path)

--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -76,6 +76,8 @@ def execute(api, entry):
         add_roles_by_name(api, users, get('addRoles'))
     elif action == 'addRolesFromTemplate':
         add_roles_from_template(api, users, get('addRolesFromTemplate'))
+    else:
+        raise ValueError('Unknown action: %s' % action)
 
 
 def wait_for_server(api, delay=30, timeout=300):

--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -102,6 +102,7 @@ def select_users(api, usernames, users_from_group_names):
 
 
 def activate(api, users):
+    debug('Activating %d user(s)...' % len(users))
     for user in users:
         user['userCredentials']['disabled'] = False
         api.put('/users/' + user['id'], user)
@@ -135,6 +136,7 @@ def add_roles_from_template(api, users, template_with_roles):
 
 
 def add_roles(api, users, roles_to_add):
+    debug('Adding %d roles to %d users...' % (len(roles_to_add), len(users)))
     for user in users:
         roles = unique(get_roles(user) + roles_to_add)
         user['userCredentials']['userRoles'] = roles

--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -3,12 +3,12 @@ Enable and add roles to selected users.
 
 Example:
 
-    >> import dhis2api
-    >> import process
-    >> api = dhis2apis.Dhis2Api('http://localhost:8080/api',
-                                username='admin', password='district')
-    >> users = process.select_users(api, usernames=['test.dataentry'])
-    >> process.add_roles(api, users, ['role1', 'role2'])
+  import dhis2api
+  import process
+  api = dhis2apis.Dhis2Api('http://localhost:8080/api',
+                           username='admin', password='district')
+  users = process.select_users(api, usernames=['test.dataentry'])
+  process.add_roles(api, users, ['role1', 'role2'])
 """
 
 import sys

--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -18,7 +18,6 @@ import requests
 import dhis2api
 
 
-
 def postprocess(cfg, entries):
     """Execute actions on the appropriate users as specified in entries.
 
@@ -62,8 +61,12 @@ def is_url(x):
 def execute(api, entry):
     "Execute the action described in one entry of the postprocessing"
     get = lambda x: entry.get(x, [])
+
     users = select_users(api, get('selectUsernames'), get('selectFromGroups'))
     debug('Users selected: %s' % ', '.join(get_username(x) for x in users))
+    if not users:
+        return
+
     action = get('action')
     if action == 'activate':
         activate(api, users)

--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -48,7 +48,7 @@ def expand_url(entry):
         return entry
     else:
         try:
-            return requests.get(x).json()
+            return requests.get(entry).json()
         except Exception as e:
             debug('Error on retrieving url with entries: %s - %s' % (entry, e))
             return {}

--- a/DHIS2/cloner/readme.rst
+++ b/DHIS2/cloner/readme.rst
@@ -57,7 +57,7 @@ optional arguments:
   --no-backups          don't make backups
   --no-webapps          don't clone the webapps
   --no-db               don't clone the database
-  --no-postprocess      don't execute postprocessing actions
+  --no-postprocess      don't do postprocessing
   --manual-restart      don't stop/start tomcat
   --post-sql POST_SQL [POST_SQL ...]
                         sql files to run post-clone

--- a/DHIS2/cloner/readme.rst
+++ b/DHIS2/cloner/readme.rst
@@ -102,10 +102,13 @@ The sections in the configuration file are:
   section needs to define a ``url``, ``username`` and ``password`` to
   connect to the running DHIS2 system after the cloning.
 * ``postprocess``: list of blocks, each containing users (specified by
-  ``usernames`` and/or ``fromGroups``) that will be activated, and
-  optionally given extra roles if specified (directly from
-  ``addRoles`` and/or from ``addRolesFromTemplate`` which will give
-  all the roles corresponding to the given user too).
+  ``selectUsernames`` and/or ``selectFromGroups``) and an ``action``
+  to perform on them (``activate`` to activate them, ``deleteOthers``
+  to keep them in exclusive, ``addRoles`` to specify a list of extra
+  roles to give, or ``addRolesFromTemplate`` to give a reference
+  username whose roles we want to add).
+* ``postprocess_url``: url with a json file describing the
+  postprocessing actions to do, as a list of blocks.
 
 .. _`conninfo`: https://www.postgresql.org/docs/9.3/static/libpq-connect.html#LIBPQ-CONNSTRING
 

--- a/DHIS2/cloner/readme.rst
+++ b/DHIS2/cloner/readme.rst
@@ -43,7 +43,7 @@ Usage
   usage: dhis2_clone [-h] [--check-only] [--no-backups] [--no-webapps] [--no-db]
                    [--no-postprocess] [--manual-restart]
                    [--post-sql POST_SQL [POST_SQL ...]] [--post-clone-scripts]
-                   [--no-color]
+                   [--update-config] [--no-color]
                    config
 
 Clone a dhis2 installation from another server.
@@ -61,10 +61,10 @@ optional arguments:
   --manual-restart      don't stop/start tomcat
   --post-sql POST_SQL [POST_SQL ...]
                         sql files to run post-clone
-  --post-clone-scripts  execute all py and sh scripts in the
-                        post_clone_scripts_dir folder
+  --post-clone-scripts  execute all py and sh scripts in
+                        post_clone_scripts_dir
+  --update-config       update the config file
   --no-color            don't use colored output
-
 
 
 Configuration
@@ -106,9 +106,9 @@ The sections in the configuration file are:
   to perform on them (``activate`` to activate them, ``deleteOthers``
   to keep them in exclusive, ``addRoles`` to specify a list of extra
   roles to give, or ``addRolesFromTemplate`` to give a reference
-  username whose roles we want to add).
-* ``postprocess_url``: url with a json file describing the
-  postprocessing actions to do, as a list of blocks.
+  username whose roles we want to add). Instead of a block, you can
+  give a url, and the blocks contained in that url will be added to
+  the list of blocks.
 
 .. _`conninfo`: https://www.postgresql.org/docs/9.3/static/libpq-connect.html#LIBPQ-CONNSTRING
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #45 
* **Related pull-requests:** None

### :tophat: What is the goal?

We wanted to make some changes in the postprocessing of `dhis2_clone`:

* Add an action to delete all users except a given list of users.
* Add option to include postprocessing actions from a remote json.
* Check the configuration file and add an option to automatically upgrade it.

### :memo: How is it being implemented?

We changed the structure of the configuration file (see `configuration_example.json`), so that each block now includes an `action`, which can be:

* `activate`: activates the selected users.
* `deleteOthers`: deletes all the non-selected users.
* `addRoles`: add given roles to selected users.
* `addRolesFromTemplate`: add the roles that a given username has to the selected users.

The only part that is not straightforward is the one related to the old and new configuration file. We created functions to detect the "version" of the configuration file, and an argument `--update-config` that can update it automatically (and is suggested if the program finds out it is using an outdated config file).

### :boom: How can it be tested?

Create a json configuration file that corresponds to two running instances of a dhis2 server, fill in the appropriate postprocessing actions to check (following the example of `configuration_example.json`) and launch the cloning like:

```
./dhis2_clone config.json
```

To simply test the changes in postprocessing, you can comment out the content of the functions `start_tomcat` and `stop_tomcat` in `dhis2_clone`, and maybe comment out the `wait_for_server` call in `server.py`, and then run:

```
./dhis2_clone config.json --no-backup --no-webapps --no-db
```

### :floppy_disk: Requires new configuration file?

- [ ] Nope, we can just use the old one (and simply merge this branch).
- [x] Yes, we need to update them.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

All the old arguments exist and have the same semantics. We do have a new one now: `--update-config`.