### PR TITLE
Import json file after cloning

### DIFF
--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -57,12 +57,16 @@ def main():
     if args.post_clone_scripts:
         execute_scripts(cfg['post_clone_scripts_dir'])
 
+    if args.post_import:
+        process.dhis2_import(cfg['post_process_import_dir'])
+
     if not args.manual_restart:
         start_tomcat(dir_local)
         if args.no_postprocess:
             log('No postprocessing done, as requested.')
         elif 'api_local' in cfg and 'postprocess' in cfg:
-            process.postprocess(cfg['api_local'], cfg['postprocess'])
+            process.postprocess(cfg['api_local'], cfg['postprocess']
+                                , cfg['post_process_import_dir'])
         else:
             log('No postprocessing done.')
     else:
@@ -84,6 +88,8 @@ def get_args():
     add('--post-sql', nargs='+', default=[], help='sql files to run post-clone')
     add('--post-clone-scripts', action='store_true',
         help='execute all py and sh scripts in post_clone_scripts_dir')
+    add('--post-import', action='store_true',
+        help='import to DHIS2 selected json files from post_process_import_dir')
     add('--update-config', action='store_true', help='update the config file')
     add('--no-color', action='store_true', help="don't use colored output")
     return parser.parse_args()
@@ -109,7 +115,7 @@ def get_config(fname, update):
 
 
 def check_config(cfg):
-    "Assert all the options in configuration exist and have reasonable values"
+    "Assert all the mandatory options in configuration exist and have reasonable values"
     for option in ['backups_dir', 'backup_name', 'hostname_remote',
                    'server_dir_local', 'server_dir_remote',
                    'db_local', 'db_remote', 'war_local', 'war_remote']:
@@ -120,7 +126,8 @@ def check_config(cfg):
     elif 'postprocess' not in cfg:
         log('Option postprocess missing. Will not do local postprocessing.')
 
-    for path in ['backups_dir', 'server_dir_local', 'post_clone_scripts_dir']:
+    for path in ['backups_dir', 'server_dir_local', 'post_clone_scripts_dir',
+                 'post_process_import_dir']:
         if cfg.has_key(path):
             assert os.path.isdir(cfg[path]), \
                 '%s is not a directory: %s' % (path, cfg[path])

--- a/DHIS2/cloner/dhis2api.py
+++ b/DHIS2/cloner/dhis2api.py
@@ -1,4 +1,7 @@
 import requests
+from jsonobject import JsonObject
+from jsonobject.properties import StringProperty
+from jsonobject.properties import IntegerProperty
 
 
 class Dhis2Api:
@@ -31,8 +34,8 @@ class Dhis2Api:
     def get(self, path, params=None):
         return self._request('get', path, params=params)
 
-    def post(self, path, payload):
-        return self._request('post', path, json=payload)
+    def post(self, path, payload, params=None):
+        return self._request('post', path, params=params, json=payload)
 
     def put(self, path, payload):
         return self._request('put', path, json=payload)
@@ -42,3 +45,23 @@ class Dhis2Api:
 
     def delete(self, path):
         return self._request('delete', path)
+
+
+class ImportSummary(JsonObject):
+    """
+    Import processes are contained in an Object of type Import Summary
+    that is represented in this object. Typically an import summary offers
+    the following information:
+    total objects,
+    objects deleted,
+    objects ignored,
+    objects updated
+    objects created
+    """
+
+    total = IntegerProperty(required=True)
+    created = IntegerProperty(required=True)
+    updated = IntegerProperty(required=True)
+    deleted = IntegerProperty(required=True)
+    ignored = IntegerProperty(required=True)
+


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #38 
* **Related pull-requests:** None

### :tophat: What is the goal?

In order to facilitate users propagation among all the DHIS2 instances that compose the WIDP, after a clone, the DHIS2 cloning script must be able to import DHIS2-ready json files, so the User Extended App can prepare those json files that the cloning script will consume. Once any json file can be imported, many other usages can be found for this new feature. The log file must show individually the result of each import process.


### :memo: How is it being implemented?

A new parameter has been created in the configuration file to define a folder where json files will be searched. Then, a system of selection + action + parameters (just like what was implemented for users) has been developed. This way, now in the configuration file not only users can be selected, but files too. 

In order to wrap the stats of the import, jsonobject python library has been used and a wrapper class created in dhis2api. 

POST method has been modified so parameters can be also provided, and the /metadata endpoint of DHIS2 is used for the import, with the most important parameters for an import recognized in the configuration file:
- mergeMode (MERGE, REPLACE)
- importStrategy (CREATE_AND_UPDATE, CREATE, UPDATE, DELETE)
- skipSharing (false, true)


### :boom: How can it be tested?

Open a WHO docker image, introduce the script in it, edit the configuration file to something like this:
```
{
    "backups_dir": "/root/cloner/backups",
    "backup_name": "DOCKER-DEV",
    "server_dir_local": "/usr/local/tomcat",
    "server_dir_remote": "/remote/folder",
    "post_clone_scripts_dir": "/root/cloner/post_clone_scripts",
    "post_process_import_dir": "/root/cloner/post_process_imports",
    "hostname_remote": "username@server",
    "db_local": "postgresql://user:pass@localhost:5432/dbname",
    "db_remote": "postgresql://user:pass@server:5432/dbname",
    "war_local": "ROOT.war",
    "war_remote": "remote.war",
    "api_local": {
        "url": "http://localhost:8080/",
        "username": "user",
        "password": "password"
    },
    "postprocess": [
        {
            "selectFiles": ["users.json"],
            "action": "import",
            "importStrategy": "CREATE_AND_UPDATE",
            "mergeMode": "MERGE",
            "skipSharing": "false"
        }
    ]
}
```
Create a users.json file using the advanced import/export app from WIDP, change a parameter of the user in the json file and generate a new user, and introduce users.json inside the post_process_import_dir configured, copy the public key in the server to clone and then run:
- The script with parameters --no-backups --no-webapps --no-db configuration_file.json (to avoid the full cloning process so it will run only the postprocess). The result should import 1 user and update another one, showing it in the debug logs. 
- Run the same script without all the parameters (but the configuration file) and check that on normall full operation it still works


### :floppy_disk: Requires any configuration file update?

- [x] Nope, we can just use the old one if any (and simply merge this branch) unless the functionality want to be used. It's backward compatible
- [ ] Yes, we need to update them.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-

