### PR TITLE
add program indicators to program description

### DIFF
--- a/DHIS2/metadata_manipulation/describe_program.py
+++ b/DHIS2/metadata_manipulation/describe_program.py
@@ -33,7 +33,7 @@ def get_args():
     add('-o', '--output', help='output file')
     add('-u', '--user', metavar='USER:PASSWORD', required=True,
         help='username and password for server authentication')
-    add('--urlbase', default='http://who-dev.essi.upc.edu:8081',
+    add('--urlbase', default='https://extranet-uat.who.int/dhis2',
         help='base url of the dhis server')
     return parser.parse_args()
 
@@ -48,6 +48,7 @@ def describe_program(program_id):
         stages = describe_stages(id_list(program['programStages']))
         rules = describe_rules(id_list(program['programRules']))
         variables = describe_variables(id_list(program['programRuleVariables']))
+        program_indicators = describe_program_indicators(id_list(program['programIndicators']))
         return """%s (%s)
 
 Attributes
@@ -60,11 +61,15 @@ Rules (name: condition --> action)
   %s
 
 Variables
+  %s
+    
+Program Indicators
   %s""" % (name, program_id,
            attributes.replace('\n', '\n  '),
            stages.replace('\n', '\n  '),
            rules.replace('\n', '\n  '),
-           variables.replace('\n', '\n  '))
+           variables.replace('\n', '\n  '),
+           program_indicators.replace('\n', '\n  '))
     except KeyError:
         return '***%s***' % program_id  # could not find it
 
@@ -209,6 +214,20 @@ def describe_variable(variable_id):
         return '%s (%s) -->%s' % (name, variable_id, extra)
     except KeyError:
         return '***%s***' % variable_id  # could not find it
+
+def describe_program_indicators(program_indicators):
+    return '\n'.join(describe_program_indicator(x) for x in program_indicators)
+
+def describe_program_indicator(program_indicator_id):
+    try:
+        var = d2.get_object(program_indicator_id)
+        name = var['name']
+        extra = '\n expression: %s' % var['filter']
+        extra += '\n filter: %s' % var['filter']
+
+        return '%s (%s) -->%s' % (name, program_indicator_id, extra)
+    except KeyError:
+        return '***%s***' % program_indicator_id  # could not find it
 
 
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes #51
* **Related pull-requests:** None

### :tophat: What is the goal?

The describe_program helps identifying how a tracker program is configured server side. It takes several minutes to run but it retrieves all the main information from it so PRs, PRVariables, DEs, etc can be quickly analyzed from a text editor. It currently didn't contain any information about the program indicators, and we needed to analyze them for an issue with ETA program in WHO

### :memo: How is it being implemented?

Mirroring what was previously done for variables, program rules, etc. Nothing new. The main info extracted from program indicators is its expression and filter.


### :boom: How can it be tested?

- Run the script passing as parameter the UID of the program. Now program indicators should be also printed out with its information


### :floppy_disk: Requires any configuration file update?

- [x] Nope, we can just use the old one if any (and simply merge this branch) unless the functionality want to be used. It's backward compatible
- [ ] Yes, we need to update them.

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-
