### PR TITLE
Feature drop view tables script

### DIFF
--- a/DHIS2/cloner/drop_view_tables.sql
+++ b/DHIS2/cloner/drop_view_tables.sql
@@ -1,41 +1,15 @@
--- Sql script to create the getTableViewNames() and dropViewTables() psql functions
--- and execute dropViewTables()
+-- Sql script to drop all the view tables
 
 -- You can run it as part of the cloning process by passing this file
 -- as argument --post-sql in dhis2_clone.
 
--- Create getTableViewNames function
--- Return a list of view tables propertly formatted
-CREATE FUNCTION getTableViewNames()
-RETURNS SETOF record
-LANGUAGE plpgsql as $$
+DO $$
 DECLARE
- rec record;
- BEGIN
-  FOR rec IN
-	SELECT CONCAT('_view_', REPLACE(LOWER(this_.name), ' ', '_'))
-	from sqlview this_ where this_.type = 'VIEW';
-  LOOP
-	return next rec;
-  END LOOP;
-END $$;
-
--- Create dropViewTables() function
-
-CREATE FUNCTION dropViewTables()
-RETURNS SETOF record
-LANGUAGE plpgsql as $$
-DECLARE
- rec record;
- BEGIN
-  FOR rec IN
-	(select * from getTableViewNames() as (names text))
-  LOOP
-	RAISE NOTICE 'DROP DATABASE %', rec;
-	'DROP DATABASE %', rec;
-  END LOOP;
-END $$;
-
--- Execute drop view tables
-
-SELECT dropViewTables();
+ rec RECORD;
+BEGIN
+	FOR rec IN SELECT CONCAT('_view_', REPLACE(LOWER(this_.name), ' ', '_')) as name from sqlview this_ where this_.type = 'VIEW'
+		LOOP
+			RAISE NOTICE 'DROP VIEW %', rec.name;
+			EXECUTE CONCAT('DROP VIEW IF EXISTS ', rec.name);
+		END LOOP;
+END; $$

--- a/DHIS2/cloner/drop_view_tables.sql
+++ b/DHIS2/cloner/drop_view_tables.sql
@@ -1,0 +1,41 @@
+-- Sql script to create the getTableViewNames() and dropViewTables() psql functions
+-- and execute dropViewTables()
+
+-- You can run it as part of the cloning process by passing this file
+-- as argument --post-sql in dhis2_clone.
+
+-- Create getTableViewNames function
+-- Return a list of view tables propertly formatted
+CREATE FUNCTION getTableViewNames()
+RETURNS SETOF record
+LANGUAGE plpgsql as $$
+DECLARE
+ rec record;
+ BEGIN
+  FOR rec IN
+	SELECT CONCAT('_view_', REPLACE(LOWER(this_.name), ' ', '_'))
+	from sqlview this_ where this_.type = 'VIEW';
+  LOOP
+	return next rec;
+  END LOOP;
+END $$;
+
+-- Create dropViewTables() function
+
+CREATE FUNCTION dropViewTables()
+RETURNS SETOF record
+LANGUAGE plpgsql as $$
+DECLARE
+ rec record;
+ BEGIN
+  FOR rec IN
+	(select * from getTableViewNames() as (names text))
+  LOOP
+	RAISE NOTICE 'DROP DATABASE %', rec;
+	'DROP DATABASE %', rec;
+  END LOOP;
+END $$;
+
+-- Execute drop view tables
+
+SELECT dropViewTables();


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #56

### :tophat: What is the goal?

Drop SQL views from cloning script before cloning

### :memo: How is it being implemented?

- I have created a SQL select query to get the list with the formatted view names and drop them.

-I read the dhis-core code to replicate the dhis drop views action:

https://github.com/dhis2/dhis2-core/blob/32b69a5673bc34ae82d0a788a9307ca7a7c40bc8/dhis-2/dhis-services/dhis-service-administration/src/main/java/org/hisp/dhis/sqlview/DefaultSqlViewService.java#L103

https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/sqlview/SqlView.java#L103

### :boom: How can it be tested?

Note: Change user by database user, database by database name
Command line:
`psql -d database -h localhost -f drop_view_tables.sql -U user`

 **Use case 1:** -
Run the command line in the docker, and check the log messages:

The first time should remove at least some existing views.


 **Use case 2:** -
Run the command line in the docker, and check the log messages:

You should view messages like:  "view xxx does not exist, skipping" for each view.

 **Use case 3:** - 
Run the command line in the docker, and check the log messages:

You shouldn't view messages like:  "view xxx does not exist, skipping" for each view.
