### PR TITLE
treat the rsync exceptions

### DIFF
--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -10,8 +10,7 @@ import os
 import time
 import json
 import argparse
-from pickle import TRUE
-from subprocess import PIPE, Popen
+from subprocess import Popen
 
 import psycopg2
 

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -3,6 +3,7 @@
 """
 Clone a dhis2 installation from another server.
 """
+import errno
 import subprocess
 import sys
 import os
@@ -19,7 +20,6 @@ import process
 
 TIME = time.strftime('%Y-%m-%d_%H%M')
 COLOR = True
-MANDATORY_FOLDERS = ['webapps']
 
 
 def main():
@@ -252,22 +252,14 @@ def backup_war(backups_dir, dir_local, war_local):
 
 
 def get_webapps(route_local, war_local, route_remote, war_remote):
-    for subdir in ['webapps', 'files']:
+    for mandatory, subdir in [[True, 'webapps'], [False, 'files']]:
         cmd = ("rsync -a --delete %s/%s/* %s/%s" % (route_remote, subdir, route_local, subdir))
         p = Popen(cmd, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
                   universal_newlines=True, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
-        if p.returncode != 0:
-            if subdir in MANDATORY_FOLDERS:
-                message = "Failed cloning {} folder with return code of {}. \n " \
-                          "stderr: {}  \n stdout: {} end of log"\
-                    .format(subdir, p.returncode, stderr, stdout)
-                log(message)
-                raise Exception(message)
-            else:
-                log('Not mandatory folder: "{}" not cloned.'.format(subdir))
-        else:
-            log('Mandatory folder: "{}" cloned.'.format(subdir))
+        if p.returncode != 0 and mandatory:
+            log('Mandatory folder %s failed to rsync' % subdir)
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT) + '\n' + stderr, subdir)
 
     if war_local != war_remote:
         commands = [

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -3,12 +3,14 @@
 """
 Clone a dhis2 installation from another server.
 """
-
+import subprocess
 import sys
 import os
 import time
 import json
 import argparse
+from pickle import TRUE
+from subprocess import PIPE, Popen
 
 import psycopg2
 
@@ -17,6 +19,7 @@ import process
 
 TIME = time.strftime('%Y-%m-%d_%H%M')
 COLOR = True
+MANDATORY_FOLDERS = ['webapps']
 
 
 def main():
@@ -250,8 +253,21 @@ def backup_war(backups_dir, dir_local, war_local):
 
 def get_webapps(route_local, war_local, route_remote, war_remote):
     for subdir in ['webapps', 'files']:
-        run("rsync -a --delete '%s/%s/*' '%s/%s'" % (route_remote, subdir,
-                                                     route_local, subdir))
+        cmd = ("rsync -a --delete %s/%s/* %s/%s" % (route_remote, subdir, route_local, subdir))
+        p = Popen(cmd, shell=True, stdout=subprocess.PIPE, stdin=subprocess.PIPE,
+                  universal_newlines=True, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        if p.returncode != 0:
+            if subdir in MANDATORY_FOLDERS:
+                message = "Failed cloning {} folder with return code of {}. \n " \
+                          "stderr: {}  \n stdout: {} end of log"\
+                    .format(subdir, p.returncode, stderr, stdout)
+                log(message)
+                raise Exception(message)
+            else:
+                log('Not mandatory folder: "{}" not cloned.'.format(subdir))
+        else:
+            log('Mandatory folder: "{}" cloned.'.format(subdir))
 
     if war_local != war_remote:
         commands = [


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #54

### :tophat: What is the goal?

Make files rsync optional

### :memo: How is it being implemented?

- I have added the subprocess library to treat the rsync command result. 

- I have added a list of mandatory folders to throw an exception if the rsync command exit with an error result.

### :boom: How can it be tested?

 **Use case 1:** - Run the clone script with tomcat/files folder in the remote server.
You can see the result of the rsync commands in the log.

 **Use case 2:** - Run the clone script without tomcat/files folder in the remote server.
You can see the result of the rsync commands in the log.

 **Use case 3:** -  Run the clone script without tomcat/webapps folder in the remote server.
You can see the result of the rsync commands in the log.