### PR TITLE
Feature/multiple input files

### DIFF
--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -146,12 +146,15 @@ def join(text, fname):
     fname = json.loads(fname)
     for key, value in fname.items():
         if key in text:
-            text[key] += value
+            if isinstance(text[key], dict):
+                text[key] = [text[key], value]
+            else:
+                text[key] += value
         elif isinstance(value, list):
             text[key] = value
         else:
             text.update(value)
-    return json.dumps(text)
+    return json.dumps(text, ensure_ascii=False)
 
 
 def apply_replacements(text, replacements):

--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -52,7 +52,7 @@ sort_fields = []
 def main():
     args = get_args()
 
-    text = get_text(args)
+    text = get_text(args.input)
 
     text = expand(compact(text))  # normalize spacing
 
@@ -126,11 +126,11 @@ def file_arg_maybe_misplaced(fname, filters):
     return not fname and filters and not all(':' in x for x in filters)
 
 
-def get_text(args):
+def get_text(input):
     "Return a text with all the input files merged"
     text = None
 
-    for file in args.input:
+    for file in input:
         file = read(file)
         if text is None:
             text = file

--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -52,7 +52,7 @@ sort_fields = []
 def main():
     args = get_args()
 
-    text = get_text(args.input)
+    text = get_input_files(args.input)
 
     text = expand(compact(text))  # normalize spacing
 
@@ -126,25 +126,25 @@ def file_arg_maybe_misplaced(fname, filters):
     return not fname and filters and not all(':' in x for x in filters)
 
 
-def get_text(input):
+def get_input_files(input):
     "Return a text with all the input files merged"
     text = None
 
-    for file in input:
-        file = read(file)
+    for fname in input:
+        fname = read(fname)
         if text is None:
-            text = file
+            text = fname
             continue
-        text = join(text, file)
+        text = join(text, fname)
 
     return text
 
 
-def join(text, file):
+def join(text, fname):
     "Return text with all the file root elements added"
     text = json.loads(text)
-    file = json.loads(file)
-    for key, value in file.items():
+    fname = json.loads(fname)
+    for key, value in fname.items():
         if key in text:
             text[key] += value
         elif isinstance(value, list):

--- a/DHIS2/metadata_manipulation/jcat_test_json/categoryOptions.json
+++ b/DHIS2/metadata_manipulation/jcat_test_json/categoryOptions.json
@@ -1,0 +1,18 @@
+{
+  "pager": {
+  "page": 1,
+  "pageCount": 2,
+  "total": 2,
+  "pageSize": 50,
+  "nextPage": "localhost"
+  },
+  "categoryOptions": [
+  {
+    "id": "uid1",
+    "displayName": "Option1"
+  },
+  {
+    "id": "uid2",
+    "displayName": "Option2"
+  }]
+}

--- a/DHIS2/metadata_manipulation/jcat_test_json/expected_join.json
+++ b/DHIS2/metadata_manipulation/jcat_test_json/expected_join.json
@@ -1,0 +1,231 @@
+{
+  "users": [
+    {
+      "lastUpdated": "2019-01-14T14:43:15.119",
+      "id": "user2uid",
+      "href": "localhost",
+      "created": "2018-11-26T13:04:41.215",
+      "externalAccess": false,
+      "favorite": false,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "userCredentials": {
+        "lastUpdated": "2018-11-26T13:04:41.075",
+        "id": "userCredentialsuid",
+        "created": "2018-11-26T13:04:41.075",
+        "lastLogin": "2019-01-04T12:32:31.329",
+        "externalAuth": false,
+        "externalAccess": false,
+        "disabled": true,
+        "twoFA": false,
+        "passwordLastUpdated": "2018-12-21T16:58:01.685",
+        "invitation": false,
+        "selfRegistered": false,
+        "favorite": false,
+        "userInfo": {
+          "id": "userinfouid"
+        },
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": true,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [],
+        "cogsDimensionConstraints": [],
+        "catDimensionConstraints": [],
+        "translations": [],
+        "userGroupAccesses": [],
+        "attributeValues": [],
+        "userRoles": [
+          {
+            "id": "userRoles1"
+          },
+          {
+            "id": "userRoles2"
+          },
+          {
+            "id": "userRoles3"
+          },
+          {
+            "id": "userRoles4"
+          },
+          {
+            "id": "userRoles5"
+          },
+          {
+            "id": "userRoles6"
+          },
+          {
+            "id": "userRoles7"
+          },
+          {
+            "id": "userRoles8"
+          },
+          {
+            "id": "userRoles9"
+          }
+        ],
+        "userAccesses": []
+      },
+      "favorites": [],
+      "teiSearchOrganisationUnits": [],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "organisationUnitsuid"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "dataViewOrganisationUnitsuid"
+        }
+      ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userGroups": [
+        {
+          "id": "userGroups1"
+        },
+        {
+          "id": "userGroups2"
+        },
+        {
+          "id": "userGroups3"
+        },
+        {
+          "id": "userGroups4"
+        },
+        {
+          "id": "userGroups5"
+        },
+        {
+          "id": "userGroups6"
+        },
+        {
+          "id": "userGroups7"
+        },
+        {
+          "id": "userGroups8"
+        },
+        {
+          "id": "userGroups9"
+        },
+        {
+          "id": "userGroups10"
+        }
+      ],
+      "userAccesses": []
+    },
+    {
+      "lastUpdated": "2018-12-14T15:44:49.211",
+      "id": "id1",
+      "href": "localhost",
+      "created": "2018-12-07T16:18:12.794",
+      "externalAccess": false,
+      "lastCheckedInterpretations": "2018-12-14T15:44:49.211",
+      "favorite": false,
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "userCredentials": {
+        "lastUpdated": "2018-12-10T11:41:44.039",
+        "created": "2018-12-10T11:41:44.039",
+        "lastLogin": "2018-12-14T15:45:35.979",
+        "externalAuth": false,
+        "externalAccess": false,
+        "disabled": false,
+        "twoFA": false,
+        "passwordLastUpdated": "2018-12-14T11:55:57.691",
+        "invitation": false,
+        "selfRegistered": false,
+        "favorite": false,
+        "userInfo": {
+          "id": "id user info"
+        },
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": true,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [],
+        "cogsDimensionConstraints": [],
+        "catDimensionConstraints": [],
+        "translations": [],
+        "userGroupAccesses": [],
+        "attributeValues": [],
+        "userRoles": [
+          {
+            "id": "rol1"
+          },
+          {
+            "id": "rol2"
+          },
+          {
+            "id": "rol3"
+          }
+        ],
+        "userAccesses": []
+      },
+      "favorites": [],
+      "teiSearchOrganisationUnits": [
+        {
+          "id": "teiuid"
+        }
+      ],
+      "translations": [],
+      "organisationUnits": [
+        {
+          "id": "orgunituid"
+        }
+      ],
+      "dataViewOrganisationUnits": [
+        {
+          "id": "dataViewOrganisationUnitsuid"
+        }
+      ],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userGroups": [
+        {
+          "id": "userGroups1"
+        },
+        {
+          "id": "userGroups2"
+        }
+      ],
+      "userAccesses": []
+    }
+  ],
+  "page": 1,
+  "pageCount": 2,
+  "total": 2,
+  "pageSize": 50,
+  "nextPage": "localhost",
+  "categoryOptions": [
+    {
+      "id": "uid1",
+      "displayName": "Option1"
+    },
+    {
+      "id": "uid2",
+      "displayName": "Option2"
+    }
+  ]
+}

--- a/DHIS2/metadata_manipulation/jcat_test_json/user1.json
+++ b/DHIS2/metadata_manipulation/jcat_test_json/user1.json
@@ -1,0 +1,89 @@
+{
+  "users": [{
+    "lastUpdated": "2018-12-14T15:44:49.211",
+    "id": "id1",
+    "href": "localhost",
+    "created": "2018-12-07T16:18:12.794",
+    "externalAccess": false,
+    "lastCheckedInterpretations": "2018-12-14T15:44:49.211",
+    "favorite": false,
+    "access": {
+      "read": true,
+      "update": true,
+      "externalize": true,
+      "delete": true,
+      "write": true,
+      "manage": true
+    },
+    "userCredentials": {
+      "lastUpdated": "2018-12-10T11:41:44.039",
+      "created": "2018-12-10T11:41:44.039",
+      "lastLogin": "2018-12-14T15:45:35.979",
+      "externalAuth": false,
+      "externalAccess": false,
+      "disabled": false,
+      "twoFA": false,
+      "passwordLastUpdated": "2018-12-14T11:55:57.691",
+      "invitation": false,
+      "selfRegistered": false,
+      "favorite": false,
+      "userInfo": {
+        "id": "id user info"
+      },
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "favorites": [],
+      "cogsDimensionConstraints": [],
+      "catDimensionConstraints": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userRoles": [
+        {
+          "id": "rol1"
+        },
+        {
+          "id": "rol2"
+        },
+        {
+          "id": "rol3"
+        }
+      ],
+      "userAccesses": []
+    },
+    "favorites": [],
+    "teiSearchOrganisationUnits": [
+      {
+        "id": "teiuid"
+      }
+    ],
+    "translations": [],
+    "organisationUnits": [
+      {
+        "id": "orgunituid"
+      }
+    ],
+    "dataViewOrganisationUnits": [
+      {
+        "id": "dataViewOrganisationUnitsuid"
+      }
+    ],
+    "userGroupAccesses": [],
+    "attributeValues": [],
+    "userGroups": [
+      {
+        "id": "userGroups1"
+      },
+      {
+        "id": "userGroups2"
+      }
+    ],
+    "userAccesses": []
+  }]
+}

--- a/DHIS2/metadata_manipulation/jcat_test_json/user2.json
+++ b/DHIS2/metadata_manipulation/jcat_test_json/user2.json
@@ -1,0 +1,128 @@
+{
+  "users": [{
+    "lastUpdated": "2019-01-14T14:43:15.119",
+    "id": "user2uid",
+    "href": "localhost",
+    "created": "2018-11-26T13:04:41.215",
+    "externalAccess": false,
+    "favorite": false,
+    "access": {
+      "read": true,
+      "update": true,
+      "externalize": true,
+      "delete": true,
+      "write": true,
+      "manage": true
+    },
+    "userCredentials": {
+      "lastUpdated": "2018-11-26T13:04:41.075",
+      "id": "userCredentialsuid",
+      "created": "2018-11-26T13:04:41.075",
+      "lastLogin": "2019-01-04T12:32:31.329",
+      "externalAuth": false,
+      "externalAccess": false,
+      "disabled": true,
+      "twoFA": false,
+      "passwordLastUpdated": "2018-12-21T16:58:01.685",
+      "invitation": false,
+      "selfRegistered": false,
+      "favorite": false,
+      "userInfo": {
+        "id": "userinfouid"
+      },
+      "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true
+      },
+      "favorites": [],
+      "cogsDimensionConstraints": [],
+      "catDimensionConstraints": [],
+      "translations": [],
+      "userGroupAccesses": [],
+      "attributeValues": [],
+      "userRoles": [
+        {
+          "id": "userRoles1"
+        },
+        {
+          "id": "userRoles2"
+        },
+        {
+          "id": "userRoles3"
+        },
+        {
+          "id": "userRoles4"
+        },
+        {
+          "id": "userRoles5"
+        },
+        {
+          "id": "userRoles6"
+        },
+        {
+          "id": "userRoles7"
+        },
+        {
+          "id": "userRoles8"
+        },
+        {
+          "id": "userRoles9"
+        }
+      ],
+      "userAccesses": []
+    },
+    "favorites": [],
+    "teiSearchOrganisationUnits": [],
+    "translations": [],
+    "organisationUnits": [
+      {
+        "id": "organisationUnitsuid"
+      }
+    ],
+    "dataViewOrganisationUnits": [
+      {
+        "id": "dataViewOrganisationUnitsuid"
+      }
+    ],
+    "userGroupAccesses": [],
+    "attributeValues": [],
+    "userGroups": [
+      {
+        "id": "userGroups1"
+      },
+      {
+        "id": "userGroups2"
+      },
+      {
+        "id": "userGroups3"
+      },
+      {
+        "id": "userGroups4"
+      },
+      {
+        "id": "userGroups5"
+      },
+      {
+        "id": "userGroups6"
+      },
+      {
+        "id": "userGroups7"
+      },
+      {
+        "id": "userGroups8"
+      },
+      {
+        "id": "userGroups9"
+      },
+      {
+        "id": "userGroups10"
+      }
+    ],
+    "userAccesses": []
+  }
+  ]
+}

--- a/DHIS2/metadata_manipulation/test_jcat.py
+++ b/DHIS2/metadata_manipulation/test_jcat.py
@@ -406,6 +406,6 @@ def test_join():
     list_of_files.append(files_directory+"categoryOptions.json")
     expected_file = jcat.read(expected_join_json)
 
-    text = jcat.get_text(list_of_files)
+    text = jcat.get_input_files(list_of_files)
 
     assert jcat.compact(text) == jcat.compact(expected_file)

--- a/DHIS2/metadata_manipulation/test_jcat.py
+++ b/DHIS2/metadata_manipulation/test_jcat.py
@@ -8,6 +8,10 @@ import pytest
 import jcat
 
 
+files_directory = "jcat_test_json/"
+expected_join_json = files_directory + "expected_join.json"
+
+
 json_text = """\
 {
   "planets": [
@@ -393,3 +397,15 @@ def test_remove_fields():
 def test_sort():
     jcat.sort_fields = ['name', 'id', 'property']
     assert jcat.jsort(json_text) == json_text_sorted
+
+
+def test_join():
+    list_of_files = list()
+    list_of_files.append(files_directory+"user2.json", )
+    list_of_files.append(files_directory+"user1.json")
+    list_of_files.append(files_directory+"categoryOptions.json")
+    expected_file = jcat.read(expected_join_json)
+
+    text = jcat.get_text(list_of_files)
+
+    assert jcat.compact(text) == jcat.compact(expected_file)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #61

### :tophat: What is the goal?

Add multiple input files to jcat and join it

### :memo: How is it being implemented?

- I have added validation to check if the input is empty

- I have added a get text method to get all the file merged

- I have added a join method to append the json root content between files.

- I have updated the tests

### :boom: How can it be tested?

 **Use case 1:** - Run the jcat script without input file.
You can see the message of error in the log.

 **Use case 2:** - Run the jcat script with only one file.
You can see the output file.

 **Use case 3:** - Run the jcat script with multiple files.
You can see the files merged in the output file.

 **Use case 3:** - Run the jcat script with multiple files and some filter.
You can see the files merged and the filter applied in the output file.

 **Use case 4:** - Run test_jcat using pytest-3