### PR TITLE
Feature/make possible add files as params

### DIFF
--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -41,18 +41,18 @@ def main():
         else:
             replacements = dict([(args.replace_ids[2 * i], args.replace_ids[2 * i + 1]) for i in range(n // 2)])
 
-    input_file = json.load(open('input.json'))
+    input_file = json.load(open(args.input))
     input_objects = [item for item in input_file.keys() if item not in args.exclude]
     for dhis_object in input_objects:
-        dhis_object_old = json.load(open('input.json')).get(dhis_object)
+        dhis_object_old = json.load(open(args.input)).get(dhis_object)
 
         if dhis_object in dhis_objects:
             if not dhis_object_old:
                 print('WARN: Ignoring not found object %s' % dhis_object)
                 continue
 
-            userAccesses_new = json.load(open('userAccesses.json'))['userAccesses']
-            userGroupAccesses_new = json.load(open('userGroupAccesses.json'))['userGroupAccesses']
+            userAccesses_new = json.load(open(args.userAccess))['userAccesses']
+            userGroupAccesses_new = json.load(open(args.userGroupAccesses))['userGroupAccesses']
 
             elements_new = []
             for element in dhis_object_old:
@@ -75,13 +75,19 @@ def main():
         else:
             output[dhis_object] = dhis_object_old
 
-    json.dump(output, open('output.json', 'wt'), indent=2)
+    json.dump(output, open(args.output, 'wt'), indent=2)
 
 
 def get_args():
     "Return arguments"
     parser = argparse.ArgumentParser(description=__doc__)
     add = parser.add_argument  # shortcut
+    add('-i', '--input', default="input.json", help='input file (read from input.json if not given)')
+    add('-o', '--output', default="output.json", help='output file (write to output.json if not given')
+    add('-ua', '--userAccess', default="userAccesses.json",
+        help='userAccess file (read from userAccesses.json if not given')
+    add('-uga', '--userGroupAccesses', default="userGroupAccesses.json",
+        help='userGroupAccesses file (read from userGroupAccesses.json if not given')
     add('--public-access', default='--------', help='set public permissions. Default: no public access (--------)')
     add('--remove-ous', action='store_true', help='remove ous assignment from programs')
     add('--remove-catcombos', action='store_true', help='remove catcombos assignment from programs')

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -27,7 +27,7 @@ dhis_objects = [
 ]
 
 
-replaceable_objects = [
+all_replaceable_objects = [
     "publicAccess",
     "userAccesses",
     "userGroupAccesses"
@@ -37,7 +37,11 @@ replaceable_objects = [
 def main():
     args = get_args()
     dhis_objects = [item for item in args.include if item not in args.exclude]
-    replaceable_objects = [item for item in args.replace_objects]
+    if args.replace_objects:
+        replaceable_objects = [item for item in args.replace_objects]
+    else:
+        replaceable_objects = all_replaceable_objects
+
     output = {}
     replacements = {}
 
@@ -84,10 +88,15 @@ def main():
 def replace_objects(args, element, replaceable_objects):
     for replaceable in replaceable_objects:
         if replaceable == "publicAccess":
-            element['publicAccess'] = args.public_access
-        else:
+            element['publicAccess'] = args.publicAccess
+        elif replaceable in all_replaceable_objects:
             file = json.load(open(args.__getattribute__(replaceable)))
             element[replaceable] = file[replaceable]
+        else:
+            print("Error: " + replaceable + " is an invalid replaceable object)")
+            print("List of valid replaceable objects: ")
+            print(all_replaceable_objects)
+            exit(0)
 
 
 def get_args():
@@ -96,13 +105,13 @@ def get_args():
     add = parser.add_argument  # shortcut
     add('-i', '--input', default="input.json", help='input file (read from input.json if not given)')
     add('-o', '--output', default="output.json", help='output file (write to output.json if not given)')
-    add('-ua', '--userAccesses', default="userAccesses.json",
+    add('-ua', '--user-accesses', dest="userAccesses", default="userAccesses.json",
         help='userAccesses file (read from userAccesses.json if not given)')
-    add('-uga', '--userGroupAccesses', default="userGroupAccesses.json",
+    add('-uga', '--userGroupAccesses', dest="userGroupAccesses", default="userGroupAccesses.json",
         help='userGroupAccesses file (read from userGroupAccesses.json if not given)')
-    add('-ro', '--replace-objects', nargs='+', default=replaceable_objects,
+    add('-ro', '--replace-objects', nargs='+', default=all_replaceable_objects,
         help='replace only the provided objects default: publicAccess, userAccesses, userGroupAccesses')
-    add('--public-access', default='--------', help='set public permissions. Default: no public access (--------)')
+    add('--public-access', default='--------', dest="publicAccess",  help='set public permissions. Default: no public access (--------)')
     add('--remove-ous', action='store_true', help='remove ous assignment from programs')
     add('--remove-catcombos', action='store_true', help='remove catcombos assignment from programs')
     add('--replace-ids', nargs='+', metavar='FROM TO', default=[],

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -12,7 +12,6 @@ dhis_objects = [
     "indicators",
     "indicatorGroups",
     "programIndicators",
-    "programIndicators",
     "optionSets",
     "dataElements",
     "programs",

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -78,6 +78,7 @@ def main():
 
     json.dump(output, open('output.json', 'wt'), indent=2)
 
+
 def get_args():
     "Return arguments"
     parser = argparse.ArgumentParser(description=__doc__)
@@ -90,6 +91,7 @@ def get_args():
     add('--include', nargs='+', default=dhis_objects, help='DHIS2 objects to include. Default: All')
     add('--exclude', nargs='+', default=[], help='DHIS2 objects to exclude. Default: None')
     return parser.parse_args()
+
 
 if __name__ == '__main__':
     main()

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -122,21 +122,28 @@ def get_args():
     "Return arguments"
     parser = argparse.ArgumentParser(description=__doc__)
     add = parser.add_argument  # shortcut
-    add('-i', '--input', default="input.json", help='input file (read from input.json if not given)')
-    add('-o', '--output', default="output.json", help='output file (write to output.json if not given)')
+    add('-i', '--input', default="input.json",
+        help='input file (read from input.json if not given)')
+    add('-o', '--output', default="output.json",
+        help='output file (write to output.json if not given)')
     add('-ua', '--user-accesses', dest="userAccesses", default="userAccesses.json",
         help='userAccesses file (read from userAccesses.json if not given)')
     add('-uga', '--userGroupAccesses', dest="userGroupAccesses", default="userGroupAccesses.json",
         help='userGroupAccesses file (read from userGroupAccesses.json if not given)')
     add('-ro', '--replace-objects', nargs='+', default=all_replaceable_objects,
         help='replace only the provided objects default: publicAccess, userAccesses, userGroupAccesses')
-    add('--public-access', default='--------', dest="publicAccess",  help='set public permissions. Default: no public access (--------)')
-    add('--remove-ous', action='store_true', help='remove ous assignment from programs')
-    add('--remove-catcombos', action='store_true', help='remove catcombos assignment from programs')
+    add('--public-access', default='--------', dest="publicAccess",
+        help='set public permissions. Default: no public access (--------)')
+    add('--remove-ous', action='store_true',
+        help='remove ous assignment from programs')
+    add('--remove-catcombos', action='store_true',
+        help='remove catcombos assignment from programs')
     add('--replace-ids', nargs='+', metavar='FROM TO', default=[],
         help='ids to replace. NOTE: references are not updated!!!')
-    add('--include', nargs='+', default=dhis_objects, help='DHIS2 objects to include. Default: All')
-    add('--exclude', nargs='+', default=[], help='DHIS2 objects to exclude. Default: None')
+    add('--include', nargs='+', default=dhis_objects,
+        help='DHIS2 objects to include. Default: All')
+    add('--exclude', nargs='+', default=[],
+        help='DHIS2 objects to exclude. Default: None')
     return parser.parse_args()
 
 

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -95,11 +95,11 @@ def get_args():
     parser = argparse.ArgumentParser(description=__doc__)
     add = parser.add_argument  # shortcut
     add('-i', '--input', default="input.json", help='input file (read from input.json if not given)')
-    add('-o', '--output', default="output.json", help='output file (write to output.json if not given')
-    add('-ua', '--userAccess', default="userAccesses.json",
-        help='userAccess file (read from userAccesses.json if not given')
+    add('-o', '--output', default="output.json", help='output file (write to output.json if not given)')
+    add('-ua', '--userAccesses', default="userAccesses.json",
+        help='userAccesses file (read from userAccesses.json if not given)')
     add('-uga', '--userGroupAccesses', default="userGroupAccesses.json",
-        help='userGroupAccesses file (read from userGroupAccesses.json if not given')
+        help='userGroupAccesses file (read from userGroupAccesses.json if not given)')
     add('-ro', '--replace-objects', nargs='+', default=replaceable_objects,
         help='replace only the provided objects default: publicAccess, userAccesses, userGroupAccesses')
     add('--public-access', default='--------', help='set public permissions. Default: no public access (--------)')

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -36,7 +36,7 @@ all_replaceable_objects = [
 
 def main():
     args = get_args()
-    dhis_objects = [item for item in args.include if item not in args.exclude]
+    dhis_objects = [item for item in args.apply if item not in args.exclude]
     if args.replace_objects:
         replaceable_objects = [item for item in args.replace_objects]
     else:
@@ -126,7 +126,7 @@ def get_args():
         help='input file (read from input.json if not given)')
     add('-o', '--output', default="output.json",
         help='output file (write to output.json if not given)')
-    add('-ua', '--user-accesses', dest="userAccesses", default="userAccesses.json",
+    add('-ua', '--userAccesses', dest="userAccesses", default="userAccesses.json",
         help='userAccesses file (read from userAccesses.json if not given)')
     add('-uga', '--userGroupAccesses', dest="userGroupAccesses", default="userGroupAccesses.json",
         help='userGroupAccesses file (read from userGroupAccesses.json if not given)')
@@ -140,7 +140,7 @@ def get_args():
         help='remove catcombos assignment from programs')
     add('--replace-ids', nargs='+', metavar='FROM TO', default=[],
         help='ids to replace. NOTE: references are not updated!!!')
-    add('--include', nargs='+', default=dhis_objects,
+    add('--apply-to-objects', dest='apply', nargs='+', default=dhis_objects,
         help='DHIS2 objects to include. Default: All')
     add('--exclude', nargs='+', default=[],
         help='DHIS2 objects to exclude. Default: None')

--- a/DHIS2/metadata_manipulation/change_user_groups.py
+++ b/DHIS2/metadata_manipulation/change_user_groups.py
@@ -38,7 +38,7 @@ def main():
     args = get_args()
     dhis_objects = [item for item in args.apply if item not in args.exclude]
     if args.replace_objects:
-        replaceable_objects = [item for item in args.replace_objects]
+        replaceable_objects = [item for item in args.replace_objects if item in all_replaceable_objects]
     else:
         replaceable_objects = all_replaceable_objects
 
@@ -51,7 +51,7 @@ def main():
     input_objects = get_input_objects(args.input, args.exclude)
 
     for dhis_object in input_objects:
-        dhis_object_old = json.load(open(args.input)).get(dhis_object)
+        dhis_object_old = json.load(open(args.input, encoding="utf-8")).get(dhis_object)
 
         if dhis_object in dhis_objects:
             if not dhis_object_old:
@@ -81,7 +81,7 @@ def replace_ids(args, element, replacements):
 
 
 def get_input_objects(input, excluded_objects):
-    input_file = json.load(open(input))
+    input_file = json.load(open(input, encoding="utf-8"))
     input_objects = [item for item in input_file.keys() if item not in excluded_objects]
     return input_objects
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #63

### :tophat: What is the goal?

- Make possible to add files using parameters
- Make possible to select what objects will be applied
- Make --include / --exclude params more readable

### :memo: How is it being implemented?

- I have replaced the --include param name by -apply-to-objects to make it more readable. 

- I have added a list with all the replaceable objects by default. When the user provides a replaceable object must be listed in that list. The script only will apply the selected replaceable objects. And I have added a --apply-to-objects param to pass the objects to be added

- I have added some new params:
	-i --input param to pass the input file
	-o --output param to pass the output file
	-ua --user-accesses param to pass the userAccesses.json file
	-uga --userGroupAccesses param to pass the userGroupAccesses.json file

- Refactor: I extract some methods from main()

- I have added an error message when the user introduces an invalid 

### :boom: How can it be tested?

 **Use case 1:** - Run the clone script without params
You can see the result on the file output.json. 

 **Use case 2:** - Run the clone script with -i/--input -o/--output options
You can see the result from the input file on the output file.

 **Use case 3:** -  Run the clone script with --apply-to-objects param
You can see the output file with only the provided objects in each item.

 **Use case 4:** -  Run the clone script with all the params.
Example:
```
change_user_groups.py -i input.json -o output.json 
-ua userAccess.json 
-uga userGroupAccess.json 
--public-access rwrwrwrwrw 
--replace-objects userGroupAccesses publicAccess userAccesses 
--apply-to-objects users dataElements
```