### PR TITLE
ignore pg_stat_statements table when cloning

### DIFF
--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -291,7 +291,7 @@ def empty_db(db_local):
     db_name = db_local.split('/')[-1]
     postgis_elements = {'geography_columns', 'geometry_columns',
                         'raster_columns', 'raster_overviews',
-                        'spatial_ref_sys'}
+                        'spatial_ref_sys', 'pg_stat_statements'}
 
     with psycopg2.connect(db_local) as conn:
         with conn.cursor() as cur:


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #70 

### :tophat: What is the goal?

Cloning failed due to pg_stat_statements table and we need to quickly repare cloning of dev and preprod

### :memo: How is it being implemented?

The pg_stat_statements extension has been activated by Simone and it creates a table that need to be excluded during the cloning of the DB. So I added it to what the cloning consider "postgis_elements"

### :boom: How can it be tested?

- [ ]  **Use case 1:** - Clone dev-cont or preprod and now it should work

### :floppy_disk: Requires any configuration file update?

- [x] Nope, we can just use the old one if any (and simply merge this branch) unless the functionality want to be used. It's backward compatible
- [ ] Yes

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-