### PR TITLE
create aspera sync script

### DIFF
--- a/cnb/aspera_sync.sh
+++ b/cnb/aspera_sync.sh
@@ -8,44 +8,48 @@ ROOT_LOCAL_FOLDER="$HOME/data"
 ROOT_REMOTE_FOLDER='/CNB/CNBPROYECTO1/CBNSHARE'
 
 syncPath(){
-        REMOTE_FOLDER=$1
-        LOCAL_DATA=$2
+        local remote_folder=$1
+        local local_data=$2
         #Get ls with formatted dates and ordered by time
-        lslist=$(TZ=utc ls $LOCAL_DATA -altr --color=auto --time-style=full-iso)
+        local local_files=$(TZ=utc ls $local_data -altr --color=auto \
+         --time-style=full-iso)
 
         #Get filenames column
-        localfilenames=$(echo "$lslist" | awk '{print $9}')
+        local local_filenames=$(echo "$local_files" | awk '{print $9}')
 
         #Get aspera folder info and remove all less files table
-        result=$(aspera shares browse -i -u $REMOTE_USER --host $REMOTE_HOST \
-         --path=$REMOTE_FOLDER --sort mtime_a |
-        sed -n  '/----/,/----/p' |sed '$d;1d;2d' )
+        local result=$(aspera shares browse -i -u $REMOTE_USER \
+        --host $REMOTE_HOST --path=$remote_folder --sort mtime_a \
+        | sed -n  '/----/,/----/p' |sed '$d;1d;2d' )
 
         echo "$result" |
-        while IFS= read -r asperarow;do
+        while IFS= read -r aspera_row;do
                 #Get aspera item values
-                filename=$(echo $asperarow | awk '{print $4}')
-                size=$(echo $asperarow | awk '{print $2}')
-                type=$(echo $asperarow | awk '{print $1}')
-                date=$(echo $asperarow | awk '{print $3}')
+                local filename=$(echo $aspera_row | awk '{print $4}')
+                local size=$(echo $aspera_row | awk '{print $2}')
+                local type=$(echo $aspera_row | awk '{print $1}')
+                local date=$(echo $aspera_row | awk '{print $3}')
 
                 #Get and convert ls and aspera dates to timestamp
-                lsfilerow=$(echo "$lslist" | sed -n '/'"$filename"'$/p')
-                if ! [ -z "$lsfilerow" ];then
-                        localdate=$(echo $lsfilerow | awk '{print $6}')
-                        localhour=$(echo $lsfilerow | awk '{print $7}')
-                        localdate=$(echo $localdate$localhour | cut -f1 -d".")
-                        localfiledate=$(busybox date -u -d $localdate -D \
-                         %Y-%m-%d%H:%M:%S)
-                        localfiledate=$(date -d "$localfiledate" +%s)
+                local local_file=$(echo "$local_files" \
+                | sed -n '/'"$filename"'$/p')
+                if ! [ -z "$local_file" ];then
+                        #format ls date to timestamp
+                        local local_date=$(echo $local_file | awk '{print $6}')
+                        local local_hour=$(echo $local_file | awk '{print $7}')
+                        local_date=$(echo $local_date$local_hour | \
+                        cut -f1 -d".")
+                        local local_file_timestamp=$(busybox date -u \
+                        -d $local_date +%s -D  %Y-%m-%d%H:%M:%S)
                 fi
-                filedate=$(busybox date -u -d $date -D %Y-%m-%dT%H:%M:%SZ)
-                filedate=$(date -d "$filedate" +%s)
+                #format aspera item date to timestamp
+                local file_timestamp=$(busybox date -u \
+                -d $date +%s -D %Y-%m-%dT%H:%M:%SZ)
 
                 #Check if the filename exist in the local filenames,
                 #and if the creation date is before than server updated date
-                if [[ "$localfilenames" == *"$filename"* ]] && \
-                [[ $filedate -lt $localfiledate ]];then
+                if [[ "$local_filenames" == *"$filename"* ]] && \
+                [[ $file_timestamp -lt local_file_timestamp ]];then
                         echo "Already exist: $filename"
                 #Ignore files with 0kb.
                 elif [ $size == 0 -a ${type:0:1} == "-" ]
@@ -54,8 +58,8 @@ syncPath(){
                 else
                         echo "Start download: $filename"
                         aspera shares download -i -u $REMOTE_USER \
-                        --host $REMOTE_HOST --source=$REMOTE_FOLDER/$filename \
-                         --destination=$LOCAL_DATA
+                        --host $REMOTE_HOST --source=$remote_folder/$filename \
+                         --destination=$local_data
                 fi
         done
 

--- a/cnb/aspera_sync.sh
+++ b/cnb/aspera_sync.sh
@@ -11,58 +11,58 @@ syncPath(){
         local remote_folder=$1
         local local_data=$2
         #Get ls with formatted dates and ordered by time
-        local local_files=$(TZ=utc ls $local_data -altr --color=auto \
+        local local_files=$(TZ=utc ls "$local_data" -altr --color=auto \
          --time-style=full-iso)
 
         #Get filenames column
-        local local_filenames=$(echo "$local_files" | awk '{print $9}')
+        local local_file_names=$(echo "$local_files" | awk '{print $9}')
 
         #Get aspera folder info and remove all less files table
-        local result=$(aspera shares browse -i -u $REMOTE_USER \
-        --host $REMOTE_HOST --path=$remote_folder --sort mtime_a \
+        local result=$(aspera shares browse -i -u "$REMOTE_USER" \
+        --host "$REMOTE_HOST" --path="$remote_folder" --sort mtime_a \
         | sed -n  '/----/,/----/p' |sed '$d;1d;2d' )
 
         echo "$result" |
         while IFS= read -r aspera_row;do
                 #Get aspera item values
-                local filename=$(echo $aspera_row | awk '{print $4}')
-                local size=$(echo $aspera_row | awk '{print $2}')
-                local type=$(echo $aspera_row | awk '{print $1}')
-                local date=$(echo $aspera_row | awk '{print $3}')
+                local filename=$(echo "$aspera_row" | awk '{print $4}')
+                local size=$(echo "$aspera_row" | awk '{print $2}')
+                local type=$(echo "$aspera_row" | awk '{print $1}')
+                local date=$(echo "$aspera_row" | awk '{print $3}')
 
                 #Get and convert ls and aspera dates to timestamp
                 local local_file=$(echo "$local_files" \
                 | sed -n '/'"$filename"'$/p')
-                if ! [ -z "$local_file" ];then
+                if ! [[ -z "$local_file" ]];then
                         #format ls date to timestamp
-                        local local_date=$(echo $local_file | awk '{print $6}')
-                        local local_hour=$(echo $local_file | awk '{print $7}')
-                        local_date=$(echo $local_date$local_hour | \
+                        local local_date=$(echo "$local_file" | awk '{print $6}')
+                        local local_hour=$(echo "$local_file" | awk '{print $7}')
+                        local_date=$(echo "$local_date$local_hour" | \
                         cut -f1 -d".")
                         local local_file_timestamp=$(busybox date -u \
-                        -d $local_date +%s -D  %Y-%m-%d%H:%M:%S)
+                        -d "$local_date" +%s -D  %Y-%m-%d%H:%M:%S)
                 fi
                 #format aspera item date to timestamp
                 local file_timestamp=$(busybox date -u \
-                -d $date +%s -D %Y-%m-%dT%H:%M:%SZ)
+                -d "$date" +%s -D %Y-%m-%dT%H:%M:%SZ)
 
                 #Check if the filename exist in the local filenames,
                 #and if the creation date is before than server updated date
-                if [[ "$local_filenames" == *"$filename"* ]] && \
-                [[ $file_timestamp -lt local_file_timestamp ]];then
+                if [[ "$local_file_names" == *"$filename"* ]] && \
+                [[ "$file_timestamp" -lt "$local_file_timestamp" ]];then
                         echo "Already exist: $filename"
                 #Ignore files with 0kb.
-                elif [ $size == 0 -a ${type:0:1} == "-" ]
+                elif [[ "$size" == 0 -a ${type:0:1} == "-" ]]
                 then
                         echo "Ignore File with 0kb: $filename"
                 else
                         echo "Start download: $filename"
-                        aspera shares download -i -u $REMOTE_USER \
-                        --host $REMOTE_HOST --source=$remote_folder/$filename \
-                         --destination=$local_data
+                        aspera shares download -i -u "$REMOTE_USER" \
+                        --host "$REMOTE_HOST" --source="$remote_folder/$filename" \
+                         --destination="$local_data"
                 fi
         done
 
 }
 
-syncPath $ROOT_REMOTE_FOLDER $ROOT_LOCAL_FOLDER
+syncPath "$ROOT_REMOTE_FOLDER" "$ROOT_LOCAL_FOLDER"

--- a/cnb/aspera_sync.sh
+++ b/cnb/aspera_sync.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+alias aspera=~/.aspera/cli/bin/aspera 
 
 REMOTE_HOST="fileshare.rediris.es"
 REMOTE_USER="adrian@eyeseetea.com"

--- a/cnb/aspera_sync.sh
+++ b/cnb/aspera_sync.sh
@@ -52,7 +52,7 @@ syncPath(){
                 [[ "$file_timestamp" -lt "$local_file_timestamp" ]];then
                         echo "Already exist: $filename"
                 #Ignore files with 0kb.
-                elif [[ "$size" == 0 -a ${type:0:1} == "-" ]]
+                elif [[ "$size" == 0 ]] && [[ ${type:0:1} == "-" ]]
                 then
                         echo "Ignore File with 0kb: $filename"
                 else

--- a/cnb/aspera_sync.sh
+++ b/cnb/aspera_sync.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+REMOTE_HOST="fileshare.rediris.es"
+REMOTE_USER="adrian@eyeseetea.com"
+ROOT_LOCAL_FOLDER="$HOME/data"
+ROOT_REMOTE_FOLDER='/CNB/CNBPROYECTO1/CBNSHARE'
+
+syncPath(){
+        REMOTE_FOLDER=$1
+        LOCAL_DATA=$2
+        #Get ls with formatted dates and ordered by time
+        lslist=`TZ=utc ls $LOCAL_DATA -altr --color=auto --time-style=full-iso`
+
+        #Get filenames column
+        localfilenames=`echo "$lslist" | awk '{print $9}'`
+
+        #Get aspera folder info and remove all less files table
+        result=`aspera shares browse -i -u $REMOTE_USER --host $REMOTE_HOST --path=$REMOTE_FOLDER  --sort mtime_a | sed -n  '/----/,/----/p' | sed '$d;1d;2d' `
+
+        echo "$result" |
+        while IFS= read -r asperarow;do
+                #Get aspera item values
+                filename=`echo $asperarow | awk '{print $4}'`
+                size=`echo $asperarow | awk '{print $2}'`
+                type=`echo $asperarow | awk '{print $1}'`
+                date=`echo $asperarow | awk '{print $3}'`
+
+                #Get and convert ls and aspera dates to timestamp
+                lsfilerow=`echo "$lslist" | sed -n '/'"$filename"'$/p'`
+                if ! [ -z "$lsfilerow" ];then
+                        localdate=`echo $lsfilerow | awk '{print $6}'`
+                        localhour=`echo $lsfilerow | awk '{print $7}'`
+                        localdate=`echo $localdate$localhour | cut -f1 -d"."`
+                        localfiledate=`busybox date -u -d $localdate -D %Y-%m-%d%H:%M:%S`
+                        localfiledate=`date -d "$localfiledate" +%s`
+                fi
+                filedate=`busybox date -u -d $date -D %Y-%m-%dT%H:%M:%SZ`
+                filedate=`date -d "$filedate" +%s`
+
+                #Check if the filename exist in the local filenames, and if the creation date is before than the server updated date
+                if [[ "$localfilenames" == *"$filename"* ]] && [[ $filedate -lt $localfiledate ]]; then
+                        echo "Already exist: $filename"
+                #Ignore files with 0kb.
+                elif [ $size == 0 -a ${type:0:1} == "-" ]
+                then
+                        echo "Ignore File with 0kb: $filename"
+                else
+                        echo "Start download: $filename"
+                        aspera shares download -i -u $REMOTE_USER --host $REMOTE_HOST --source=$REMOTE_FOLDER/$filename --destination=$LOCAL_DATA
+                fi
+        done
+
+}
+
+syncPath $ROOT_REMOTE_FOLDER $ROOT_LOCAL_FOLDER

--- a/cnb/aspera_sync.sh
+++ b/cnb/aspera_sync.sh
@@ -11,36 +11,41 @@ syncPath(){
         REMOTE_FOLDER=$1
         LOCAL_DATA=$2
         #Get ls with formatted dates and ordered by time
-        lslist=`TZ=utc ls $LOCAL_DATA -altr --color=auto --time-style=full-iso`
+        lslist=$(TZ=utc ls $LOCAL_DATA -altr --color=auto --time-style=full-iso)
 
         #Get filenames column
-        localfilenames=`echo "$lslist" | awk '{print $9}'`
+        localfilenames=$(echo "$lslist" | awk '{print $9}')
 
         #Get aspera folder info and remove all less files table
-        result=`aspera shares browse -i -u $REMOTE_USER --host $REMOTE_HOST --path=$REMOTE_FOLDER  --sort mtime_a | sed -n  '/----/,/----/p' | sed '$d;1d;2d' `
+        result=$(aspera shares browse -i -u $REMOTE_USER --host $REMOTE_HOST \
+         --path=$REMOTE_FOLDER --sort mtime_a |
+        sed -n  '/----/,/----/p' |sed '$d;1d;2d' )
 
         echo "$result" |
         while IFS= read -r asperarow;do
                 #Get aspera item values
-                filename=`echo $asperarow | awk '{print $4}'`
-                size=`echo $asperarow | awk '{print $2}'`
-                type=`echo $asperarow | awk '{print $1}'`
-                date=`echo $asperarow | awk '{print $3}'`
+                filename=$(echo $asperarow | awk '{print $4}')
+                size=$(echo $asperarow | awk '{print $2}')
+                type=$(echo $asperarow | awk '{print $1}')
+                date=$(echo $asperarow | awk '{print $3}')
 
                 #Get and convert ls and aspera dates to timestamp
-                lsfilerow=`echo "$lslist" | sed -n '/'"$filename"'$/p'`
+                lsfilerow=$(echo "$lslist" | sed -n '/'"$filename"'$/p')
                 if ! [ -z "$lsfilerow" ];then
-                        localdate=`echo $lsfilerow | awk '{print $6}'`
-                        localhour=`echo $lsfilerow | awk '{print $7}'`
-                        localdate=`echo $localdate$localhour | cut -f1 -d"."`
-                        localfiledate=`busybox date -u -d $localdate -D %Y-%m-%d%H:%M:%S`
-                        localfiledate=`date -d "$localfiledate" +%s`
+                        localdate=$(echo $lsfilerow | awk '{print $6}')
+                        localhour=$(echo $lsfilerow | awk '{print $7}')
+                        localdate=$(echo $localdate$localhour | cut -f1 -d".")
+                        localfiledate=$(busybox date -u -d $localdate -D \
+                         %Y-%m-%d%H:%M:%S)
+                        localfiledate=$(date -d "$localfiledate" +%s)
                 fi
-                filedate=`busybox date -u -d $date -D %Y-%m-%dT%H:%M:%SZ`
-                filedate=`date -d "$filedate" +%s`
+                filedate=$(busybox date -u -d $date -D %Y-%m-%dT%H:%M:%SZ)
+                filedate=$(date -d "$filedate" +%s)
 
-                #Check if the filename exist in the local filenames, and if the creation date is before than the server updated date
-                if [[ "$localfilenames" == *"$filename"* ]] && [[ $filedate -lt $localfiledate ]]; then
+                #Check if the filename exist in the local filenames,
+                #and if the creation date is before than server updated date
+                if [[ "$localfilenames" == *"$filename"* ]] && \
+                [[ $filedate -lt $localfiledate ]];then
                         echo "Already exist: $filename"
                 #Ignore files with 0kb.
                 elif [ $size == 0 -a ${type:0:1} == "-" ]
@@ -48,7 +53,9 @@ syncPath(){
                         echo "Ignore File with 0kb: $filename"
                 else
                         echo "Start download: $filename"
-                        aspera shares download -i -u $REMOTE_USER --host $REMOTE_HOST --source=$REMOTE_FOLDER/$filename --destination=$LOCAL_DATA
+                        aspera shares download -i -u $REMOTE_USER \
+                        --host $REMOTE_HOST --source=$REMOTE_FOLDER/$filename \
+                         --destination=$LOCAL_DATA
                 fi
         done
 


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Trello card: Test aspera installation to new aspera share point

### :tophat: What is the goal?

The idea is to create a script that automatically detects any change in the file share and download it. 
To decide which file or directory to download, the script compares the dates and names obtained with the ls command, against the Aspera browse table. 
If a date is before the date of the server, the file must be downloaded again.
The wrong files on the server side will be ignored.

### :memo: How is it being implemented?

I used ls to get the local info, and Aspera browser command to get the remote info.
I used the sed and awk commands to extract each file information.
 
I used the busybox date command to transform the local and server dates in seconds.

### :boom: How can it be tested?

 **Use case 1:** - Run the script in a user with Aspera properly installed.

All the files and server should be download

 **Use case 2:** - Run the script again

All it's already downloaded.

 **Use case 3:** - Add a file or create a directory using the Aspera web client, and run the script again

The modified objects will be downloaded.