### PR TITLE
escape \r in a string text

### DIFF
--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -167,7 +167,7 @@ def decode_filter(expression):
 def read_filters(fname):
     "Return list of filters [(part, field, regexp), ...] from file fname"
     filters = []
-    for line_dirty in open(fname):
+    for line_dirty in open(fname, encoding="utf-8"):
         line = line_dirty.strip()
         if line and not line.startswith('#'):
             filters.append(decode_filter(line))
@@ -185,10 +185,10 @@ def read(fname):
         zf = zipfile.ZipFile(fname)
         assert len(zf.filelist) == 1, \
             'Zip file "%s" should contain only one file' % fname
-        with zf.open(zf.filelist[0]) as fin:
+        with zf.open(zf.filelist[0], encoding="utf-8") as fin:
             return fin.read().decode('utf8')
     else:
-        with open(fname) as fin:
+        with open(fname, encoding="utf-8") as fin:
             return fin.read()
 
 
@@ -225,7 +225,7 @@ def join(text, fname):
 
 def write(fname, text):
     if fname:
-        with open(fname, 'wt') as fout:
+        with open(fname, 'wt', encoding="utf-8") as fout:
             fout.write(text)
     else:
         print(text, end='')

--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -390,7 +390,7 @@ def sort(x):
 
 def jstr(x):
     "Return a json representation of the given string"
-    return '"%s"' % x.replace('"', '\\"').replace('\n', '\\n')
+    return '"%s"' % x.replace('"', '\\"').replace('\n', '\\n').replace('\r', '\\r')
 
 
 def sort_key(x):


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #73

### :tophat: What is the goal?

Sort E.T.A.json

### :memo: How is it being implemented?

In this case, the string "\r" adds tabbed new lines that break the .json format. I escaped this string with "\\r".


### :boom: How can it be tested?


 **Use case 1:** - 
Execute the command line:
ESTools/DHIS2/metadata_manipulation/jcat.py ETA-2.30-not_ordered.json -s -o ETA-2.30-1.0.0.json

Check the output file.