### PR TITLE
added post tomcat scripts

### DIFF
--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -230,22 +230,20 @@ def magenta(txt):
 
 
 def execute_post_clone_scripts(dirname):
-    execute_scripts(dirname, False)
+    execute_scripts(dirname)
 
 
 def execute_scripts_post_tomcat(dirname):
-    execute_scripts(dirname, True)
+    execute_scripts(dirname, is_post_tomcat=True)
 
 
-def execute_scripts(dirname, is_post_tomcat):
+def execute_scripts(dirname, is_post_tomcat=False):
     is_script = lambda fname: os.path.splitext(fname)[-1] in ['.sh', '.py']
-    for script in sorted(filter(is_script, os.listdir(dirname))):
-        if is_post_tomcat:
-            if script.startswith("post"):
-                run('"%s/%s"' % (dirname, script))
-        else:
-            if not script.startswith("post"):
-                run('"%s/%s"' % (dirname, script))
+    is_post = lambda fname: fname.startswith("post")
+    files_list = filter(is_post, os.listdir(dirname)) if is_post_tomcat else os.listdir(dirname)
+
+    for script in sorted(filter(is_script, files_list)):
+        run('"%s/%s"' % (dirname, script))
 
 
 def start_tomcat(server_path):

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -57,7 +57,7 @@ def main():
         run_sql(db_local, args.post_sql)
 
     if args.post_clone_scripts:
-        execute_scripts(cfg['post_clone_scripts_dir'])
+        execute_post_clone_scripts(cfg['post_clone_scripts_dir'])
 
     if not args.manual_restart:
         start_tomcat(dir_local)
@@ -69,6 +69,10 @@ def main():
                                 , import_dir)
         else:
             log('No postprocessing done.')
+
+        if args.post_clone_scripts:
+            execute_scripts_post_tomcat(cfg['post_clone_scripts_dir'])
+
     else:
         log('Server not started automatically, as requested.')
         log('No postprocessing done.')
@@ -225,10 +229,23 @@ def magenta(txt):
     return '\x1b[35m%s\x1b[0m' % txt
 
 
-def execute_scripts(dirname):
+def execute_post_clone_scripts(dirname):
+    execute_scripts(dirname, False)
+
+
+def execute_scripts_post_tomcat(dirname):
+    execute_scripts(dirname, True)
+
+
+def execute_scripts(dirname, is_post_tomcat):
     is_script = lambda fname: os.path.splitext(fname)[-1] in ['.sh', '.py']
     for script in sorted(filter(is_script, os.listdir(dirname))):
-        run('"%s/%s"' % (dirname, script))
+        if is_post_tomcat:
+            if script.startswith("post"):
+                run('"%s/%s"' % (dirname, script))
+        else:
+            if not script.startswith("post"):
+                run('"%s/%s"' % (dirname, script))
 
 
 def start_tomcat(server_path):

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -57,7 +57,7 @@ def main():
         run_sql(db_local, args.post_sql)
 
     if args.post_clone_scripts:
-        execute_post_clone_scripts(cfg['post_clone_scripts_dir'])
+        execute_scripts(cfg['post_clone_scripts_dir'])
 
     if not args.manual_restart:
         start_tomcat(dir_local)
@@ -71,7 +71,7 @@ def main():
             log('No postprocessing done.')
 
         if args.post_clone_scripts:
-            execute_scripts_post_tomcat(cfg['post_clone_scripts_dir'])
+            execute_scripts(cfg['post_clone_scripts_dir'], is_post_tomcat=True)
 
     else:
         log('Server not started automatically, as requested.')
@@ -227,14 +227,6 @@ def log(txt):
 
 def magenta(txt):
     return '\x1b[35m%s\x1b[0m' % txt
-
-
-def execute_post_clone_scripts(dirname):
-    execute_scripts(dirname)
-
-
-def execute_scripts_post_tomcat(dirname):
-    execute_scripts(dirname, is_post_tomcat=True)
 
 
 def execute_scripts(dirname, is_post_tomcat=False):

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -231,8 +231,10 @@ def magenta(txt):
 
 def execute_scripts(dirname, is_post_tomcat=False):
     is_script = lambda fname: os.path.splitext(fname)[-1] in ['.sh', '.py']
+    is_normal = lambda fname: not fname.startswith("post")
     is_post = lambda fname: fname.startswith("post")
-    files_list = filter(is_post, os.listdir(dirname)) if is_post_tomcat else os.listdir(dirname)
+    applied_filter = is_post if is_post_tomcat else is_normal
+    files_list = filter(applied_filter, os.listdir(dirname))
 
     for script in sorted(filter(is_script, files_list)):
         run('"%s/%s"' % (dirname, script))


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #68 

### :tophat: What is the goal?

There are scripts that are executed before tomcat is launched. Now we need to add scripts that are executed right after the tomcat is launched...so after the postprocessing

### :memo: How is it being implemented?

I have added the execution of post tomcat scripts after the execution of the tomcat.
These scripts are in the post_clone_scripts_dir folder, but their name has to start by post


### :boom: How can it be tested?

Add some scripts in the post_clone_scripts_dir.

And add at least one script called post*

 **Use case 1:** - Run that command line with the correct config.json, and check the order of the scripts. All the scripts that start with "post" should be executed at the end of the clone script.


