### PR TITLE
fix drop view table

### DIFF
--- a/DHIS2/cloner/drop_view_tables.sql
+++ b/DHIS2/cloner/drop_view_tables.sql
@@ -7,7 +7,7 @@ DO $$
 DECLARE
  rec RECORD;
 BEGIN
-	FOR rec IN SELECT CONCAT('_view_', REPLACE(LOWER(this_.name), ' ', '_')) as name from sqlview this_ where this_.type = 'VIEW'
+     	FOR rec IN SELECT CONCAT('_view_', REPLACE(REPLACE(LOWER(this_.name), ' ', '_'), '_-_', '_')) as name from sqlview this_ where this_.type = 'VIEW'
 		LOOP
 			RAISE NOTICE 'DROP VIEW %', rec.name;
 			EXECUTE CONCAT('DROP VIEW IF EXISTS ', rec.name);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** -

### :tophat: What is the goal?

Fix error:
```
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_nhwa_data_audit
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_nhwa_data_elements
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_orgunitstructure
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_test2
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_test
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_nhwa_dashboard_subscribers
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: NOTICE:  DROP VIEW _view_datadictionary_-_dashboard_join
psql:/home/tomcatuser/cloner/drop_view_tables.sql:15: ERROR:  syntax error at or near "-"
LINE 1: DROP VIEW IF EXISTS _view_datadictionary_-_dashboard_join
                                                 ^
QUERY:  DROP VIEW IF EXISTS _view_datadictionary_-_dashboard_join
CONTEXT:  PL/pgSQL function inline_code_block line 8 at EXECUTE

```
### :memo: How is it being implemented?

I have to replace the  "\_-\_"  by ''

### :boom: How can it be tested?

 **Use case 1:** - Run the script using cont-dev db
