### PR TITLE
Feature reimport dataset

### DIFF
--- a/DHIS2/cloner/configuration_example.json
+++ b/DHIS2/cloner/configuration_example.json
@@ -1,18 +1,29 @@
 {
     "backups_dir": "/home/user/backups",
     "backup_name": "TRAINING",
-    "server_dir_local": "/home/user/server",
+    "server_dir_local": "/usr/local/tomcat",
     "server_dir_remote": "/home/user/server",
     "hostname_remote": "prod",
     "db_local": "postgresql://user:pass@server_local:5432/db",
     "db_remote": "postgresql://user:pass@server_remote:5432/db",
-    "war_local": "dhis2-demo.war",
+    "keep_data_folder": "/home/user/keep_data",
+    "war_local": "dhis2.war",
     "war_remote": "dhis2.war",
     "api_local": {
         "url": "http://localhost:8080",
-        "username": "system",
-        "password": "System123"
+        "username": "user",
+        "password": "pass"
     },
+    "keep_data":[
+          {
+              "type": "dataset",
+              "ou_uid": "H8RixfF8ugH",
+              "dataset_uid": "Wxl8hxuOsIQ",
+              "startdate": "2014-04-01",
+              "enddate": "2019-04-30",
+              "removeuids": ["Lkjp0MFLDov"]
+          }
+    ],
     "postprocess": [
         {
             "selectUsernames": ["guest"],

--- a/DHIS2/cloner/dhis2_clone
+++ b/DHIS2/cloner/dhis2_clone
@@ -53,6 +53,11 @@ def main():
     if not args.no_db:
         get_db(db_local, db_remote, cfg['hostname_remote'])
 
+    if cfg['keep_data']:
+        start_tomcat(dir_local)
+        process.export_keep_data(cfg['api_local'], cfg['keep_data_folder'], cfg['keep_data'])
+        stop_tomcat(dir_local)
+
     if args.post_sql:
         run_sql(db_local, args.post_sql)
 
@@ -73,6 +78,8 @@ def main():
         if args.post_clone_scripts:
             execute_scripts(cfg['post_clone_scripts_dir'], is_post_tomcat=True)
 
+        if cfg['keep_data']:
+            import_keep_data(cfg['api_local'], cfg['keep_data_folder'], cfg['keep_data'])
     else:
         log('Server not started automatically, as requested.')
         log('No postprocessing done.')
@@ -347,6 +354,15 @@ def run_sql(db_local, post_sql):
     for fname in post_sql:
         run("psql -d '%s' < '%s'" % (db_local, fname))
 
+def import_keep_data(cfg, folder, keep_data):
+    for data in keep_data:
+        if data['type'] == 'dataset':
+            file = folder + "/" + data['dataset_uid']+data['ou_uid']+".json"
+            response = process.import_data_set(cfg, file)
+            if response.get('status') == 'OK':
+                log(folder + "/" + data['dataset_uid']+"-"+data['ou_uid']+".json imported")
+            else:
+                log(folder + "/" + data['dataset_uid']+"-"+data['ou_uid']+".json failed")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### :pushpin: References
* **Issue:** trello card Add feature to export and reimport data from a dataset during cloning

### :tophat: What is the goal?

- Export a dataset data
- Re-import that dataset after remove all the database with the sql file.

### :memo: How is it being implemented?

- I have added the following new config options:
    "keep_data_folder": "/home/user/keep_data" to save the exported datavalues.
And the following filters:
    "keep_data":[
          {
              "type": "dataset",
              "ou_uid": "H8RixfF8ugH",
              "dataset_uid": "Wxl8hxuOsIQ",
              "startdate": "2014-04-01",
              "enddate": "2019-04-30",
              "removeuids": ["Lkjp0MFLDov"]
          }
    ],
To identify and import the dataset.


### :boom: How can it be tested?
Run the clone script before config the configuration_example with the correct values(server, passwd, etc):

/DHIS2/cloner/configuration_example.json --post-clone-scripts --post-import --no-db --no-backups --no-webapps --post-sql empty_data_tables_228.sql