### PR TITLE
Feature/add validation rules

### DIFF
--- a/DHIS2/metadata_manipulation/describe_program.py
+++ b/DHIS2/metadata_manipulation/describe_program.py
@@ -265,9 +265,11 @@ def describe_program_indicator(program_indicator_id):
     try:
         var = d2.get_object(program_indicator_id)
         name = var['name']
-        extra = '\n expression: %s' % var['filter']
+        extra = ""
+        if('expression' in var.keys()):
+            extra = '\n expression: %s' % var['expression']
+        if ('filter' in var.keys()):
             extra += '\n filter: %s' % var['filter']
-
         return '%s (%s) -->%s' % (name, program_indicator_id, extra)
     except KeyError:
         return '***%s***' % program_indicator_id  # could not find it


### PR DESCRIPTION
### :pushpin: References
* **Issue:** http://who-dev.essi.upc.edu:8083/issues/2182

### :tophat: What is the goal?

- List all the NHWA validation rules

### :memo: How is it being implemented?
I have added two params:
 "type" to select program or validation rules. Program by default
 "filter" to provide a custom filter used by validation rules query. "filter=name:$like:Mod&fields=[id,name,operator,periodType,instruction,leftSide,rightSide,notificationTemplates]" by default.



### :boom: How can it be tested?
Run the script:
uid(ignoredforvalidationrules) -o validationrulesoutput.json -u user:password --urlbase url --type validationRules