### PR TITLE
[Feature] Allow removing users from groups

### DIFF
--- a/DHIS2/cloner/configuration_example.json
+++ b/DHIS2/cloner/configuration_example.json
@@ -33,6 +33,12 @@
             "action": "addRolesFromTemplate",
             "addRolesFromTemplate": "teacher.template"
         },
+        {
+            "selectUsernames": ["guest"],
+            "selectFromGroups": ["program1"],
+            "action": "removeFromGroups",
+            "removeFromGroups": ["program1"]
+        },
         "https://raw.githubusercontent.com/EyeSeeTea/ESTools/master/DHIS2/cloner/configuration_example_only_postprocess.json"
     ]
 }


### PR DESCRIPTION
* **Issue:** Closes #91

### Description

- You can now remove any user from a group if it was assigned to it (post-processing API action).
- The rest of users assigned to the group are kept.
- Properties from the group are left unchanged.
- You can eventually remove all the users in the group by selecting all the users in the group. 

### How to test

```python
#!/usr/bin/env python3

import dhis2api
import process
api = dhis2api.Dhis2Api('https://taris.sferadev.com/who-dev',
                           username='user', password='pass!')
users = process.select_users(api, [], [
                             'NHWA _DATA Capture Module 1'])
process.remove_groups(api, users, ['NHWA _DATA Capture Module 1'])
```
