### PR TITLE
increase time and fix query

### DIFF
--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -104,7 +104,7 @@ def execute(api, entry, cfg, import_dir):
         raise ValueError('Unknown action: %s' % action)
 
 
-def wait_for_server(api, delay=30, timeout=300):
+def wait_for_server(api, delay=90, timeout=900):
     "Sleep until server is ready to accept requests"
     debug('Check active API: %s' % api.api_url)
     time.sleep(delay)  # in case tomcat is still starting
@@ -251,7 +251,7 @@ def change_server_name(api, new_name):
         debug('No new name provided - Cancelling server name change')
         return []
 
-    response = api.post('/26/systemSettings/applicationTitle',
+    response = api.post('/30/systemSettings/applicationTitle',
                         '%s' % ''.join(new_name), contenttype='text/plain')
 
     debug('change server result: %s' % response['message'])


### PR DESCRIPTION
### :pushpin: References
* **Issue:** No issue

### :tophat: What is the goal?

- Solve an error on DEV-CONT during the cloning because of the machine starting too slow

### :memo: How is it being implemented?

I just added some more time waiting for the machine to wake up, and to avoid overloading it, also to the delay between checks. Finally I upgraded the api call for changing the instance title to 30 instead of 26, so it's preprared for the future

### :boom: How can it be tested?
Run the script normally with DEV-CONT machine and it should work