### PR TITLE
Script/remove unused indexes

### DIFF
--- a/DHIS2/instance_manipulation/postgresql_drop_unused_indexes.sh
+++ b/DHIS2/instance_manipulation/postgresql_drop_unused_indexes.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Written by demofly for Pg 9.4
+# Adapted by EyeSeeTea Ltd for Pg 10
+#
+# WARNING: if you ran pg_stat_reset() last month, don't use this script !!!
+#
+# Get unused indexes and kill it with fire!
+
+DB=db
+user=user
+pass=pass
+host=localhost
+port=5432
+
+echo "select
+    indexrelid::regclass as index
+from
+    pg_stat_user_indexes
+    JOIN pg_index USING (indexrelid)
+where
+    idx_scan = 0 and indisunique is false;
+" | psql -d postgresql://${user}:${pass}@${host}:${port}/"${DB}" -A | tail -n+2 | head -n-1 | while read IDX
+do
+    SQL="DROP INDEX CONCURRENTLY ${IDX}"
+    echo "${SQL}"
+    echo "${SQL}" | psql -d postgresql://${user}:${pass}@${host}:${port}/"${DB}"
+done


### PR DESCRIPTION
### :pushpin: References
* **Issue:** no issue

### :tophat: What is the goal?
- Remove unused indexes from a DHIS2 database

### :memo: How is it being implemented?
I have created a simple shell script with only 5 variables to adjust (db, user, pass, host and port). It connects to the postgresql DB, looks for indexes with idx_scan=0 (so never used) and drop them one by one. when there are several indexes the script can take some time to run.

### :boom: How can it be tested?
Configure variables in the script pointing to a DHIS2 database and then just run it with `./postgresql_drop_unused_indexes.sh`
