### PR TITLE
Feature/activate multiple users

### DIFF
--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -129,9 +129,14 @@ def select_users(api, usernames, users_from_group_names):
 
 def activate(api, users):
     debug('Activating %d user(s)...' % len(users))
+    users_limited_by_50 = list()
     for user in users:
         user['userCredentials']['disabled'] = False
-        api.put('/users/' + user['id'], user)
+        users_limited_by_50.append(user)
+        if len(users_limited_by_50) == 50:
+            debug('Activating %d user(s)...' % len(users_limited_by_50))
+            api.post('/metadata?importStrategy=CREATE_AND_UPDATE&mergeMode=REPLACE', {"users": users_limited_by_50})
+            users_limited_by_50 = list()
 
 
 def delete_others(api, users):

--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -130,13 +130,23 @@ def select_users(api, usernames, users_from_group_names):
 def activate(api, users):
     debug('Activating %d user(s)...' % len(users))
     users_limited_by_50 = list()
+    count = 0
     for user in users:
         user['userCredentials']['disabled'] = False
         users_limited_by_50.append(user)
+        last_count_position=count
         if len(users_limited_by_50) == 50:
-            debug('Activating %d user(s)...' % len(users_limited_by_50))
-            api.post('/metadata?importStrategy=CREATE_AND_UPDATE&mergeMode=REPLACE', {"users": users_limited_by_50})
+            count = count + len(users_limited_by_50)
+            post_activate(api, last_count_position, count, users_limited_by_50)
             users_limited_by_50 = list()
+    if len(users_limited_by_50) > 0:
+        count = count + len(users_limited_by_50)
+        post_activate(api, last_count_position, count, users_limited_by_50)
+
+
+def post_activate(api, last_count_position, count, users_limited_by_50):
+    debug('Activating from %d to %d ...' % (last_count_position, count))
+    api.post('/metadata?importStrategy=CREATE_AND_UPDATE&mergeMode=REPLACE', {"users": users_limited_by_50})
 
 
 def delete_others(api, users):


### PR DESCRIPTION
### :pushpin: References
* **Issue:** http://who-dev.essi.upc.edu:8083/issues/2598

### :tophat: What is the goal?

- Clean the list of actions in training config file.
- Activate multiple users in groups of 50 instead of one by one.

### :memo: How is it being implemented?
I have modified the api call from /users/ID to use the metadata endpoint like user advanced app.

### :boom: How can it be tested?
Run the script with the action:
	{
            "selectFromGroups": ["ADMIN reactivate after cloning"],
            "action": "activate"
        }
