### PR TITLE
added remove duplicate indices script

### DIFF
--- a/DHIS2/instance_manipulation/remove_duplicate_indices.sh
+++ b/DHIS2/instance_manipulation/remove_duplicate_indices.sh
@@ -1,0 +1,18 @@
+DB=""
+user=""
+pass=""
+host=""
+port=5432
+echo "SELECT (array_agg(idx))[2] AS index
+FROM (
+    SELECT indexrelid::regclass AS idx, (indrelid::text ||E'\n'|| indclass::text ||E'\n'|| indkey::text ||E'\n'||
+                                         COALESCE(indexprs::text,'')||E'\n' || COALESCE(indpred::text,'')) AS KEY
+    FROM pg_index) sub
+GROUP BY KEY HAVING COUNT(*)>1
+ORDER BY SUM(pg_relation_size(idx)) DESC;
+" | psql -d postgresql://${user}:${pass}@${host}:${port}/"${DB}" -A | tail -n+2 | head -n-1 | while read IDX
+do
+    SQL="DROP INDEX CONCURRENTLY ${IDX}"
+    echo "${SQL}"
+    echo "${SQL}" | psql -d postgresql://${user}:${pass}@${host}:${port}/"${DB}"
+done


### PR DESCRIPTION
### :pushpin: References
* **Issue:** http://who-dev.essi.upc.edu:8083/issues/2434

### :tophat: What is the goal?

- Clean the duplicate indices

### :memo: How is it being implemented?
- A bash script that deletes the indexes found in each iteration.

### :boom: How can it be tested?
Edit the script to configure the database server user password, and run the script using bash.