### PR TITLE
added fake data set datavalue generator

### DIFF
--- a/DHIS2/metadata_manipulation/create_fake_datavalues/config.json
+++ b/DHIS2/metadata_manipulation/create_fake_datavalues/config.json
@@ -1,0 +1,42 @@
+{
+	"config": {
+		"output_prefix": "datavalues",
+		"max_data_value_by_file": "5000",
+		"default_category_option_combo": "Xr12mI7VPn3",
+		"default_attribute_option_combo": "Xr12mI7VPn3",
+		"user": "",
+		"password": "",
+		"url": "http://localhost:8083"
+	},
+	"datasets": [{
+		"id": "uid",
+		"period_type": "daily",
+		"start_date": "2018-11-11",
+		"end_date": "2019-12-12",
+		"data_elements": [{
+				"id": "uid",
+				"coc": "uid",
+				"aoc": "uid",
+				"rule": "rain"
+			},
+			{
+				"id": "uid",
+				"rule": "temp"
+			}
+		],
+		"orgunits": [{
+			"id": "uid"
+		}, {
+			"id": "uid"
+		}]
+	}],
+	"rules": [{
+		"key": "temp",
+		"limit_up": "40",
+		"limit_down": "0"
+	}, {
+		"key": "rain",
+		"limit_up": "32",
+		"limit_down": "0"
+	}]
+}

--- a/DHIS2/metadata_manipulation/create_fake_datavalues/config_example.json
+++ b/DHIS2/metadata_manipulation/create_fake_datavalues/config_example.json
@@ -1,0 +1,42 @@
+{
+	"config": {
+		"output_prefix": "datavalues",
+		"max_data_value_by_file": "5000",
+		"default_category_option_combo": "Xr12mI7VPn3",
+		"default_attribute_option_combo": "Xr12mI7VPn3",
+		"user": "",
+		"password": "",
+		"url": "http://localhost:8083"
+	},
+	"datasets": [{
+		"id": "uid",
+		"period_type": "daily",
+		"start_date": "2018-11-11",
+		"end_date": "2019-12-12",
+		"data_elements": [{
+				"id": "uid",
+				"coc": "uid",
+				"aoc": "uid",
+				"rule": "rain"
+			},
+			{
+				"id": "uid",
+				"rule": "temp"
+			}
+		],
+		"orgunits": [{
+			"id": "uid"
+		}, {
+			"id": "uid"
+		}]
+	}],
+	"rules": [{
+		"key": "temp",
+		"limit_up": "40",
+		"limit_down": "0"
+	}, {
+		"key": "rain",
+		"limit_up": "32",
+		"limit_down": "0"
+	}]
+}

--- a/DHIS2/metadata_manipulation/create_fake_datavalues/fake_dataset_data_value_generator.py
+++ b/DHIS2/metadata_manipulation/create_fake_datavalues/fake_dataset_data_value_generator.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+
+"""
+Data set data value fake generator
+"""
+import copy
+import sys
+import json
+import argparse
+import random
+
+from cloner import dhis2api
+
+output_skell = {"dataValues": []}
+
+
+def main():
+
+    global api
+
+    args = get_args()
+
+    cfg = get_config(args.config)
+    output_preffix = cfg["config"]["output_prefix"]
+    max_values = cfg["config"]["max_data_value_by_file"]
+    default_coc = cfg["config"]["default_category_option_combo"]
+    default_aoc = cfg["config"]["default_attribute_option_combo"]
+    user = cfg["config"]["user"]
+    password = cfg["config"]["password"]
+    url = cfg["config"]["url"]
+    rules = cfg["rules"]
+    data_sets = cfg["datasets"]
+
+    datavalues_limited_by_max = generate_data_values(max_values, default_coc, default_aoc, data_sets, rules)
+
+    generate_json_files(datavalues_limited_by_max, output_preffix)
+
+    if args.update:
+        print ("Pushing values to dhis2 server")
+        api = dhis2api.Dhis2Api(url, user, password)
+
+        for data_values in datavalues_limited_by_max:
+            for data in data_values["dataValues"]:
+                query = get_query(data)
+                response = api.post("/dataValues", params=query, payload=None, contenttype="text/html;charset=utf-8")
+
+                print (response)
+    print ("Done.")
+
+def get_query(data):
+    query = ("de=%s&co=%s&ds=%s&ou=%s&pe=%s&value=%s" % (data["dataElement"], data["categoryOptionCombo"], data["dataset_uid"], data["orgUnit"], data["period"],data["value"]))
+    return query
+
+
+def get_args():
+    "Return arguments"
+    parser = argparse.ArgumentParser(description=__doc__)
+    add = parser.add_argument  # shortcut
+    add('-c', '--config', default="config.json", help='file with configuration')
+    add('-u', '--update', action='store_true', help='output a compacted json')
+    return parser.parse_args()
+
+
+def get_config(fname):
+    "Return dict with the options read from configuration file"
+    print('Reading from config file %s ...' % fname)
+    try:
+        with open(fname) as f:
+            config = json.load(f)
+    except (AssertionError, IOError, ValueError) as e:
+        sys.exit('Error reading config file %s: %s' % (fname, e))
+    return config
+
+
+def convert_date(orig_date, date_format):
+    from datetime import datetime
+    orig_date = str(orig_date)
+    d = datetime.strptime(orig_date, '%Y-%m-%d %H:%M:%S')
+    d = d.strftime(date_format)
+    return d
+
+
+def get_dates(start_date, end_date, period_type):
+    date_generated = generate_dates(end_date, start_date)
+    return convert_dates_to_periods(date_generated, period_type)
+
+
+def convert_dates_to_periods(date_generated, period_type):
+    if period_type == "daily":
+        date_format = "%Y%m%d"
+    date_formatted = [convert_date(x, date_format) for x in date_generated]
+    return date_formatted
+
+
+def generate_dates(end_date, start_date):
+    import datetime
+    date_format = "%Y-%m-%d"
+    start = datetime.datetime.strptime(start_date, date_format)
+    end = datetime.datetime.strptime(end_date, date_format)
+    date_generated = [start + datetime.timedelta(days=x) for x in range(0, (end - start).days)]
+    return date_generated
+
+
+def get_value(rule, rules):
+    for rule_action in rules:
+        if rule_action["key"] == rule:
+            return random.randint(int(rule_action["limit_down"]), int(rule_action["limit_up"]))
+    print ("not rule detected for %s" %(rule))
+    return 0
+
+
+def generate_data_values(max_values, coc, aoc, data_sets, rules):
+    count = 0
+    data_values = list()
+    data_values.append(copy.deepcopy(output_skell))
+    for data_set in data_sets:
+            dates = get_dates(data_set["start_date"], data_set["end_date"], data_set["period_type"])
+            for date in dates:
+                for org_unit in data_set["orgunits"]:
+                    for data_element in data_set["data_elements"]:
+                        data_value = get_data_value(aoc, coc, data_element, data_set["id"], date, org_unit, rules)
+                        count = check_data_value_limit(count, data_values, max_values)
+                        data_values[count]["dataValues"].append(data_value)
+
+    return data_values
+
+
+def get_data_value(aoc, coc, data_element, dataset, date, org_unit, rules):
+    if "coc" in data_element.keys():
+        coc = data_element["coc"]
+    if "aoc" in data_element.keys():
+        aoc = data_element["aoc"]
+    data_value = (data_element["id"], date, org_unit["id"], coc, aoc, get_value(data_element["rule"], rules))
+    data_value_formatted = ({"dataElement": data_value[0], "period": data_value[1],
+                             "orgUnit": data_value[2], "categoryOptionCombo": data_value[3],
+                             "attributeOptionCombo": data_value[4], "value": data_value[5], "dataset_uid": dataset})
+    return data_value_formatted
+
+
+def check_data_value_limit(count, data_values, max_values):
+    if len(data_values[count]['dataValues']) == int(max_values):
+        count = count + 1
+        data_values.append(copy.deepcopy(output_skell))
+    return count
+
+
+def generate_json_files(datavalues_limited_by_max, output_preffix):
+    count = 0
+    for datavalues in datavalues_limited_by_max:
+        count = count + 1
+        file_name = output_preffix +"_"+ str(count) + ".json"
+        with open(file_name, 'w') as outfile:
+            json.dump(datavalues, outfile)
+            print("Datavalues saved on file: "+file_name)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### :pushpin: References

### :tophat: What is the goal?

- Generate a JSON with fake data values

### :memo: How is it being implemented?

I have created a python script that reads data elements, rules, periods, and org units from the configuration file and returns .json files ready to import using data import.

I have also added the option to upload online, but it is very slow because it goes one by one.

### :boom: How can it be tested?

It is necessary to modify the config.json file with the data we want to create.

There is an example with some false data in config_example.json 

"output_prefix": is the prefix used by the output files. 

"max_data_value_by_file": Is the limit of data values ​​for each file. 

"default_category_option_combo": This value is used when we do not provide a coc. 

"default_attribute_option_combo": This value is used when we do not provide an aoc. 

"user", "password", "url": These values ​​are only necessary for the "upload" option. The upload option is passed as a parameter -u if you want to use it. 

"datasets":  list of datasets

"datasets": [{ "id": only required for the online upload 
"period_type": Currently we only have one type available, daily. 
"start_date": Start date for fake data. 
"end_date": end date 

"data_elements": list of data elements
"data_elements": [{ "id": data element uid 
"coc": category option combo uid  (if we want to use the default coc we can remove it).
"aoc": attribute option combo uid (if we want to use the default aoc we can remove it).

"rule": the selected rule key for that data element. 
"orgunits": List of org units for which we will create the false data 

"rules": List of rules with their parameters (key, limit up and limit down). 
At this moment, the rules only apply random between the limit_down and limit_up, but we can have different limits for each rule.