### PR TITLE
print json stats

### DIFF
--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -75,7 +75,10 @@ def main():
 
     text = fix(text)
 
-    write(args.output, text)
+    if args.stats:
+        print_stats(text)
+    else:
+        write(args.output, text)
 
 
 def get_args():
@@ -103,6 +106,7 @@ def get_args():
         default=['name', 'id', 'property'],
         help='fields to use for sorting the elements')
     add('-c', '--compact', action='store_true', help='output a compacted json')
+    add('-t', '--stats', action='store_true', help='print stats about json file instead of the file')
     args = parser.parse_args()
 
     sort_fields = args.sort_fields
@@ -222,6 +226,11 @@ def join(text, fname):
             text.update(value)
     return json.dumps(text, ensure_ascii=False)
 
+def print_stats(text):
+    "Prints the object keys and number of objects inside each collection at root level"
+    stats = json.loads(text)
+    for key, value in stats.items():
+        print("%s : %d objects" % (key, len(value)))
 
 def write(fname, text):
     if fname:


### PR DESCRIPTION
### :pushpin: References
* **Issue:** No issue

### :tophat: What is the goal?

Sometimes we just need to print the objects that are contained in the json file and the number of each. This is an alternative to print the file itself

### :memo: How is it being implemented?

json.loads create a dictionary and we just print the items of the dictionary and the length of each item

### :boom: How can it be tested?

- [ ]  **Use case 1:** - Execute jcat with --stats parameter on a well-formed json file

### :floppy_disk: Requires any configuration file update?

- [x] Nope, we can just use the old one if any (and simply merge this branch) unless the functionality want to be used. It's backward compatible
- [ ] Yes

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-