### PR TITLE
fix filter for non-strings

### DIFF
--- a/DHIS2/metadata_manipulation/jcat.py
+++ b/DHIS2/metadata_manipulation/jcat.py
@@ -320,7 +320,7 @@ def filter_parts(text, jfilter, multi=False):
             if not multi and current_field != '':
                 sys.exit('Error: multiple fields named "%s" in %s (you may run '
                          'with --multi)' % (jfilter.field, jfilter.part))
-            current_field = line.split('"')[3]  #   "field_name":"field_value"
+            current_field = line.split(':')[1].strip('"')
         else:  # keep adding to region
             current_region += line + '\n'
     return text_filtered


### PR DESCRIPTION
### :pushpin: References
* **Issue:** No issue

### :tophat: What is the goal?

jcat filter was failing to match (and producing an error) when the field to be matched was not in the form "key" : "value" but in the form "key" : value (like with integers in DHIS2).

### :memo: How is it being implemented?

The line that match the value has been changed so it doesn't rely on the " symbols to split

### :boom: How can it be tested?

- [ ]  **Use case 1:** - Execute jcat on a OU json file filtering by the OU level, like in:
```
jcat VNM_forImport.json --filters organisationUnits:level:3 -o VNM_forImport_lev
el3.json
```
- [ ]  **Use case 2:** - Execute jcat on a OU json file filtering by the path, like in:
```
jcat VNM_forImport_level4.json --filters organisationUnits:path:\/EZOzJAh8oXc\/av3fkpFxEXj\/[^abcdefghijkABCDEFGHIJK01234567890][a-zA-Z0-9]* -o VNM_forImport_level4_l-z.json
```
### :floppy_disk: Requires any configuration file update?

- [x] Nope, we can just use the old one if any (and simply merge this branch) unless the functionality want to be used. It's backward compatible
- [ ] Yes

### :art: UI changes?

- [x] Nope, the UI remains as beautiful as it was before!
- [ ] Yeap, here you have some screenshots-