### PR TITLE
Feature/add backup script params

### DIFF
--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -9,10 +9,10 @@ db_pass=
 db_name=
 dump_dest_path=
 dump_remote_dest_path=
-db_remote_dest_server=
+
+####
+db_remote_dest_server=""
 fail=0
-
-
 period_name=""
 format="c"
 timestamp=$(date +%Y-%m-%d_%H%M)
@@ -45,7 +45,7 @@ if [ "$1" = "day-in-week" ] || [ "$1" = "week-in-month" ] || [ "$1" = "month-in-
                                 period_name=$((($(date +%-d)-1)/7+1))
 				case $period_name in
 					1 )
-						period_name="FIRST_WEEK-"
+						period_name="FIRST-WEEK-"
 						;;
 					2 )
 						period_name="SECOND-WEEK-"
@@ -115,7 +115,7 @@ assign_params () {
 	        -f | --format )
 					assign_format $2
 					shift 2
-	                                ;;
+	        ;;
 		-d | --destine)
 					assign_destine $2
 					shift 2
@@ -123,7 +123,7 @@ assign_params () {
 	        *)
 					assign_name $1 
 					shift
-	    	                        ;;
+	    	   ;;
     esac
 done
 }
@@ -151,13 +151,13 @@ backup () {
 
 	backup_name=${backup_name}-${timestamp}
 
-	if [ "$format" = "c" ]
+	if [ "$format" = " -Fc" ]
 	then
 		backup_name="${backup_name}_cformat.dump"
 	fi
 
 	backup_file=BACKUP-${period_name}-${backup_name}
-	
+	echo "[${timestamp}] Generating backup into ${backup_file}..."
 	pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} ${format}
 	check_status 1
 	if [ "$db_remote_dest_server" != "" ] && [ "$fail" = 0 ]

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -113,7 +113,7 @@ assign_params() {
 
 assign_name() {
   backup_name=$1
-  backup_name=${backup_name}
+  backup_name=-${backup_name}
 }
 
 check_status() {
@@ -129,10 +129,10 @@ check_status() {
 backup() {
   if [ "$backup_name" = "" ] && [ "$period_name" = "" ]; then
     backup_name=$no_name
-    backup_name=${backup_name}-${timestamp}
+    backup_name=-${backup_name}-${timestamp}
   fi
 
-  backup_file=BACKUP-${dhis2_instance}-${period_name}-${backup_name}
+  backup_file=BACKUP-${dhis2_instance}-${period_name}${backup_name}
   if [ "$format" = "c" ]; then
     backup_file="${backup_file}_cformat.dump"
     echo "[${timestamp}] Generating custom backup into ${backup_file}..."
@@ -144,7 +144,7 @@ backup() {
   fi
 
   check_status 1
-  if [ "$db_remote_dest_server" != "" ]; then
+  if [ "$db_remote_dest_server" == "" ]; then
     exit 0
   fi
   if [ "$fail" = 0 ]; then

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -128,7 +128,6 @@ check_status() {
 
 backup() {
   if [ "$backup_name" = "" ] && [ "$period_name" = "" ]; then
-   then
     backup_name=$no_name
     backup_name=${backup_name}-${timestamp}
   fi

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -42,22 +42,22 @@ assign_periodicity() {
       period_name=$((($(date +%-d) - 1) / 7 + 1))
       case $period_name in
       1)
-        period_name="FIRST-WEEK-"
+        period_name="FIRST-WEEK"
         ;;
       2)
-        period_name="SECOND-WEEK-"
+        period_name="SECOND-WEEK"
         ;;
       3)
-        period_name="THIRD-WEEK-"
+        period_name="THIRD-WEEK"
         ;;
       4)
-        period_name="FOURTH-WEEK-"
+        period_name="FOURTH-WEEK"
         ;;
       esac
       ;;
     month-in-year)
       period_name=$(date +"%B" | tr 'a-z' 'A-Z')
-      period_name=$period_name"-MONTH-"
+      period_name=$period_name
       ;;
     esac
 

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -14,7 +14,7 @@ dump_remote_dest_path=
 db_remote_dest_server=""
 fail=0
 period_name=""
-format="c"
+format="custom"
 timestamp=$(date +%Y-%m-%d_%H%M)
 no_name="MANUAL"
 backup_name=""
@@ -113,7 +113,7 @@ assign_params() {
 
 assign_name() {
   backup_name=$1
-  backup_name=-${backup_name}
+  backup_name=${backup_name}
 }
 
 check_status() {
@@ -133,7 +133,7 @@ backup() {
   fi
 
   backup_file=BACKUP-${dhis2_instance}-${period_name}${backup_name}
-  if [ "$format" = "c" ]; then
+  if [ "$format" = "custom" ]; then
     backup_file="${backup_file}_cformat.dump"
     echo "[${timestamp}] Generating custom backup into ${backup_file}..."
     pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} -Fc

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -22,11 +22,11 @@ backup_name=""
 usage() {
   echo "~~~~~~~~~USAGE~~~~~~~~~~~~"
   echo "./backup_db.sh [NAME]"
-  echo "./backup_db.sh [NAME] --periodicity [PERIOD] --format [FORMAT NAME] --destine [DESTINE_HOST]"
+  echo "./backup_db.sh [NAME] --periodicity [PERIOD] --format [FORMAT NAME] --destination [DESTINATION_HOST]"
   echo "Valid periods: day-in-week week-in-month month-in-year"
   echo "Valid formats: custom / plain"
-  echo "Destine: host"
-  echo "Example: ./backup_db.sh --periodicity day-in-week --format custom --destine gva11sucherubi.who.int"
+  echo "Destination: host"
+  echo "Example: ./backup_db.sh --periodicity day-in-week --format custom --destination gva11sucherubi.who.int"
   echo "If no PERIOD is given, then a manual dump is generated with timestamp, otherwise the given period is used in the name of the destination file."
 }
 
@@ -78,11 +78,11 @@ assign_format() {
   fi
 }
 
-assign_destine() {
+assign_destination() {
   if [ "$1" != "" ]; then
     db_remote_dest_server="$1"
   else
-    echo "Error, destine is empty"
+    echo "Error, destination is empty"
     usage
     exit 1
   fi
@@ -99,8 +99,8 @@ assign_params() {
       assign_format $2
       shift 2
       ;;
-    -d | --destine)
-      assign_destine $2
+    -d | --destination)
+      assign_destination $2
       shift 2
       ;;
     *)

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -132,16 +132,17 @@ backup() {
     backup_name=${backup_name}-${timestamp}
   fi
 
-  backup_file=BACKUP-${period_name}-${backup_name}
-  echo "[${timestamp}] Generating backup into ${backup_file}..."
+  backup_file=BACKUP-${dhis2_instance}-${period_name}-${backup_name}
   if [ "$format" = "c" ]; then
-    backup_name="${backup_name}_cformat.dump"
+    backup_file="${backup_file}_cformat.dump"
+    echo "[${timestamp}] Generating custom backup into ${backup_file}..."
     pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} -Fc
   else
-    pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} -Fp | gzip > ${backup_name}.sql.tar.gz
+    backup_file="${backup_file}.sql.tar.gz"
+    echo "[${timestamp}] Generating plain backup into ${backup_file}"
+    pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -Fp | gzip > ${dump_dest_path}/${backup_file}
   fi
 
-  ${format}
   check_status 1
   if [ "$db_remote_dest_server" != "" ]; then
     exit 0

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -1,40 +1,205 @@
 #!/bin/sh
 #set -x
 
+#config options
+dhis2_instance=
+db_server=
+db_user=
+db_pass=
+db_name=
+dump_dest_path=
+dump_remote_dest_path=
+db_remote_dest_server=
+fail=0
+
+
+period_name=""
+format="c"
 timestamp=$(date +%Y-%m-%d_%H%M)
-period=
+no_name="MANUAL"
+backup_name=""
 
-if [ $# -gt 1 ]; then
-  echo "wrong parameter number" 
-  exit 1
-elif [ $# -eq 1 ]; then
-  if [ "$1" == "-h" -o "$1" == "--help" ]; then
-    echo "USAGE: ./backup_db.sh [PERIOD]" 
-    echo "If no PERIOD is given, then a manual dump is generated with timestamp, otherwise the given period is used in the name of the destination file." 
-    exit
-  fi
-  period=$1
-else
-  period=MANUAL-${timestamp}
+
+usage ()
+{
+    echo "~~~~~~~~~USAGE~~~~~~~~~~~~"
+    echo "./backup_db.sh [NAME]"
+    echo "./backup_db.sh [NAME] --periodicity [PERIOD] --format [FORMAT NAME] --destine [DESTINE_HOST]"
+    echo "Valid periods: day-in-week week-in-month month-in-year"
+    echo "Valid formats: custom / plain"
+    echo "Destine: host"
+    echo "Example: ./backup_db.sh --periodicity day-in-week --format custom --destine gva11sucherubi.who.int"
+    echo "If no PERIOD is given, then a manual dump is generated with timestamp, otherwise the given period is used in the name of the destination file."
+}
+
+
+assign_periodicity () {
+if [ "$1" = "day-in-week" ] || [ "$1" = "week-in-month" ] || [ "$1" = "month-in-year" ]
+	then
+		case $1 in
+                        day-in-week )
+                                period_name=`date '+%A'  | tr 'a-z' 'A-Z'`
+                                period_name=$period_name
+                        ;;
+                        week-in-month )
+                                period_name=$((($(date +%-d)-1)/7+1))
+				case $period_name in
+					1 )
+						period_name="FIRST_WEEK-"
+						;;
+					2 )
+						period_name="SECOND-WEEK-"
+						;;
+					3 )
+						period_name="THIRD-WEEK-" 
+						;;
+					4 )
+						period_name="FOURTH-WEEK-"
+						;;
+				esac
+                        ;;
+                        month-in-year)
+                                period_name=`date +"%B" | tr 'a-z' 'A-Z'`
+                                period_name=$period_name"-MONTH-"
+                        ;;
+		esac
+
+	else
+	        echo "ERROR: invalid period"
+	        usage
+	        exit 1
 fi
+}
 
-dhis2_instance=XXX
-db_server=xxxxx.xxx.xxx
-db_user=xxxxxx
-db_pass=xxxxxxxx
-db_name=xxxxxx
-dump_dest_path=/xxxxxxxx/xxxxx
+assign_format_param () {
+if [ "$1" = "custom" ] 
+then
+	format=" -Fc"
+else
+if [ "$1" = "plain" ] 
+then
+	format=" -Fp | gzip > archivo archivo.sql.tar.gz "
+fi
+fi
+}
 
-check_status(){
-check_status(){
+assign_format () {
+if [ "$1" = "custom" ] || [ "$1" = "plain" ]
+then
+	assign_format_param $1
+else
+	echo "ERROR: invalid format"
+	usage
+	exit 1
+fi
+}
+
+assign_destine () {
+if [ "$1" != "" ] 
+then
+	db_remote_dest_server="$1"
+else
+	echo "Error, destine is empty"
+	usage
+	exit 1
+fi
+}
+
+assign_params () {
+	while [ "$1" != "" ]; do
+	    case $1 in
+	        -p | --periodicity )
+					assign_periodicity $2
+					shift 2
+					;;
+	        -f | --format )
+					assign_format $2
+					shift 2
+	                                ;;
+		-d | --destine)
+					assign_destine $2
+					shift 2
+					;;
+	        *)
+					assign_name $1 
+					shift
+	    	                        ;;
+    esac
+done
+}
+
+assign_name () {
+	backup_name=$1
+}
+
+check_status () {
     if [ $? -eq 0 ]; then
         echo OK
     else
         echo FAIL
+	fail=$1
+	exit $1
     fi
 }
 
-backup_file=BACKUP-${dhis2_instance}-${period}_cformat.dump
-echo "[${timestamp}] Generating backup into ${backup_file}..." 
-pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -Fc -f ${dump_dest_path}/${backup_file}
-check_status
+
+backup () {
+	if [ "$backup_name" = "" ]
+	then
+		backup_name=$no_name
+	fi
+
+	backup_name=${backup_name}-${timestamp}
+
+	if [ "$format" = "c" ]
+	then
+		backup_name="${backup_name}_cformat.dump"
+	fi
+
+	backup_file=BACKUP-${period_name}-${backup_name}
+	
+	pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} ${format}
+	check_status 1
+	if [ "$db_remote_dest_server" != "" ] && [ "$fail" = 0 ]
+	then
+		echo "[${timestamp}] CP backup into ${db_remote_dest_server}..."
+		scp ${dump_dest_path}/${backup_file} ${db_remote_dest_server}:${dump_remote_dest_path}
+		check_status 2
+	else
+		echo "The cp of the other server is not executed because the backup has failed"
+	fi
+}
+              
+
+main () {
+	if [ "$#" = "0" ]
+		then
+			backup
+			exit 0
+	fi
+	if [ "$#" = "1" ]
+		then
+			if [ "$1" == "-h" ] | [ "$1" == "--help" ]
+				then
+					usage
+					exit 0
+				else
+					assign_name $1
+					backup
+					shift
+					exit 0
+				fi
+	fi
+	if [ "$#" -gt 1 ]
+		then
+			assign_params $@
+			backup
+		else
+			usage
+			exit 1
+	fi
+}
+
+		
+main $@
+exit 0

--- a/DHIS2/backups/backup_db.sh
+++ b/DHIS2/backups/backup_db.sh
@@ -19,190 +19,171 @@ timestamp=$(date +%Y-%m-%d_%H%M)
 no_name="MANUAL"
 backup_name=""
 
-
-usage ()
-{
-    echo "~~~~~~~~~USAGE~~~~~~~~~~~~"
-    echo "./backup_db.sh [NAME]"
-    echo "./backup_db.sh [NAME] --periodicity [PERIOD] --format [FORMAT NAME] --destine [DESTINE_HOST]"
-    echo "Valid periods: day-in-week week-in-month month-in-year"
-    echo "Valid formats: custom / plain"
-    echo "Destine: host"
-    echo "Example: ./backup_db.sh --periodicity day-in-week --format custom --destine gva11sucherubi.who.int"
-    echo "If no PERIOD is given, then a manual dump is generated with timestamp, otherwise the given period is used in the name of the destination file."
+usage() {
+  echo "~~~~~~~~~USAGE~~~~~~~~~~~~"
+  echo "./backup_db.sh [NAME]"
+  echo "./backup_db.sh [NAME] --periodicity [PERIOD] --format [FORMAT NAME] --destine [DESTINE_HOST]"
+  echo "Valid periods: day-in-week week-in-month month-in-year"
+  echo "Valid formats: custom / plain"
+  echo "Destine: host"
+  echo "Example: ./backup_db.sh --periodicity day-in-week --format custom --destine gva11sucherubi.who.int"
+  echo "If no PERIOD is given, then a manual dump is generated with timestamp, otherwise the given period is used in the name of the destination file."
 }
 
-
-assign_periodicity () {
-if [ "$1" = "day-in-week" ] || [ "$1" = "week-in-month" ] || [ "$1" = "month-in-year" ]
-	then
+assign_periodicity() {
+  if [ "$1" = "day-in-week" ] || [ "$1" = "week-in-month" ] || [ "$1" = "month-in-year" ]; then
     backup_name=""
-		case $1 in
-                        day-in-week )
-                                period_name=`date '+%A'  | tr 'a-z' 'A-Z'`
-                                period_name=$period_name
-                        ;;
-                        week-in-month )
-                                period_name=$((($(date +%-d)-1)/7+1))
-				case $period_name in
-					1 )
-						period_name="FIRST-WEEK-"
-						;;
-					2 )
-						period_name="SECOND-WEEK-"
-						;;
-					3 )
-						period_name="THIRD-WEEK-" 
-						;;
-					4 )
-						period_name="FOURTH-WEEK-"
-						;;
-				esac
-                        ;;
-                        month-in-year)
-                                period_name=`date +"%B" | tr 'a-z' 'A-Z'`
-                                period_name=$period_name"-MONTH-"
-                        ;;
-		esac
-
-	else
-	        echo "ERROR: invalid period"
-	        usage
-	        exit 1
-fi
-}
-
-assign_format_param () {
-if [ "$1" = "custom" ] 
-then
-	format=" -Fc"
-else
-if [ "$1" = "plain" ] 
-then
-	format=" -Fp | gzip > archivo archivo.sql.tar.gz "
-fi
-fi
-}
-
-assign_format () {
-if [ "$1" = "custom" ] || [ "$1" = "plain" ]
-then
-	assign_format_param $1
-else
-	echo "ERROR: invalid format"
-	usage
-	exit 1
-fi
-}
-
-assign_destine () {
-if [ "$1" != "" ] 
-then
-	db_remote_dest_server="$1"
-else
-	echo "Error, destine is empty"
-	usage
-	exit 1
-fi
-}
-
-assign_params () {
-	while [ "$1" != "" ]; do
-	    case $1 in
-	        -p | --periodicity )
-					assign_periodicity $2
-					shift 2
-					;;
-	        -f | --format )
-					assign_format $2
-					shift 2
-	        ;;
-		-d | --destine)
-					assign_destine $2
-					shift 2
-					;;
-	        *)
-					assign_name $1 
-					shift
-	    	   ;;
+    case $1 in
+    day-in-week)
+      period_name=$(date '+%A' | tr 'a-z' 'A-Z')
+      period_name=$period_name
+      ;;
+    week-in-month)
+      period_name=$((($(date +%-d) - 1) / 7 + 1))
+      case $period_name in
+      1)
+        period_name="FIRST-WEEK-"
+        ;;
+      2)
+        period_name="SECOND-WEEK-"
+        ;;
+      3)
+        period_name="THIRD-WEEK-"
+        ;;
+      4)
+        period_name="FOURTH-WEEK-"
+        ;;
+      esac
+      ;;
+    month-in-year)
+      period_name=$(date +"%B" | tr 'a-z' 'A-Z')
+      period_name=$period_name"-MONTH-"
+      ;;
     esac
-done
+
+  else
+    echo "ERROR: invalid period"
+    usage
+    exit 1
+  fi
 }
 
-assign_name () {
-	backup_name=$1
-	backup_name=${backup_name}-${timestamp}
-}
-
-check_status () {
-    if [ $? -eq 0 ]; then
-        echo OK
-    else
-        echo FAIL
-	fail=$1
-	exit $1
+assign_format_param() {
+  if [ "$1" = "custom" ]; then
+    format=" -Fc"
+  else
+    if [ "$1" = "plain" ]; then
+      format=" -Fp | gzip > archivo archivo.sql.tar.gz "
     fi
+  fi
 }
 
+assign_format() {
+  if [ "$1" = "custom" ] || [ "$1" = "plain" ]; then
+    assign_format_param $1
+  else
+    echo "ERROR: invalid format"
+    usage
+    exit 1
+  fi
+}
 
-backup () {
-	if [ "$backup_name" = "" ]
-	then
-		backup_name=$no_name
-	  backup_name=${backup_name}-${timestamp}
-	fi
+assign_destine() {
+  if [ "$1" != "" ]; then
+    db_remote_dest_server="$1"
+  else
+    echo "Error, destine is empty"
+    usage
+    exit 1
+  fi
+}
 
-	if [ "$format" = " -Fc" ]
-	then
-		backup_name="${backup_name}_cformat.dump"
-	fi
+assign_params() {
+  while [ "$1" != "" ]; do
+    case $1 in
+    -p | --periodicity)
+      assign_periodicity $2
+      shift 2
+      ;;
+    -f | --format)
+      assign_format $2
+      shift 2
+      ;;
+    -d | --destine)
+      assign_destine $2
+      shift 2
+      ;;
+    *)
+      assign_name $1
+      shift
+      ;;
+    esac
+  done
+}
 
-	backup_file=BACKUP-${period_name}-${backup_name}
-	echo "[${timestamp}] Generating backup into ${backup_file}..."
-	pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} ${format}
-	check_status 1
-	if [ "$db_remote_dest_server" != "" ]
-  then
+assign_name() {
+  backup_name=$1
+  backup_name=${backup_name}-${timestamp}
+}
+
+check_status() {
+  if [ $? -eq 0 ]; then
+    echo OK
+  else
+    echo FAIL
+    fail=$1
+    exit $1
+  fi
+}
+
+backup() {
+  if [ "$backup_name" = "" ]; then
+    backup_name=$no_name
+    backup_name=${backup_name}-${timestamp}
+  fi
+
+  if [ "$format" = " -Fc" ]; then
+    backup_name="${backup_name}_cformat.dump"
+  fi
+
+  backup_file=BACKUP-${period_name}-${backup_name}
+  echo "[${timestamp}] Generating backup into ${backup_file}..."
+  pg_dump -d "postgresql://${db_user}:${db_pass}@${db_server}:5432/${db_name}" --no-owner --exclude-table 'aggregated*' --exclude-table 'analytics*' --exclude-table 'completeness*' --exclude-schema sys -f ${dump_dest_path}/${backup_file} ${format}
+  check_status 1
+  if [ "$db_remote_dest_server" != "" ]; then
     exit 0
-	fi
-	if [ "$fail" = 0 ]
-	then
-		echo "[${timestamp}] CP backup into ${db_remote_dest_server}..."
-		scp ${dump_dest_path}/${backup_file} ${db_remote_dest_server}:${dump_remote_dest_path}
-		check_status 2
-	fi
-}
-              
-
-main () {
-	if [ "$#" = "0" ]
-		then
-			backup
-			exit 0
-	fi
-	if [ "$#" = "1" ]
-		then
-			if [ "$1" == "-h" ] | [ "$1" == "--help" ]
-				then
-					usage
-					exit 0
-				else
-					assign_name $1
-					backup
-					shift
-					exit 0
-				fi
-	fi
-	if [ "$#" -gt 1 ]
-		then
-			assign_params $@
-			backup
-		else
-			usage
-			exit 1
-	fi
+  fi
+  if [ "$fail" = 0 ]; then
+    echo "[${timestamp}] CP backup into ${db_remote_dest_server}..."
+    scp ${dump_dest_path}/${backup_file} ${db_remote_dest_server}:${dump_remote_dest_path}
+    check_status 2
+  fi
 }
 
-		
+main() {
+  if [ "$#" = "0" ]; then
+    backup
+    exit 0
+  fi
+  if [ "$#" = "1" ]; then
+    if [ "$1" == "-h" ] | [ "$1" == "--help" ]; then
+      usage
+      exit 0
+    else
+      assign_name $1
+      backup
+      shift
+      exit 0
+    fi
+  fi
+  if [ "$#" -gt 1 ]; then
+    assign_params $@
+    backup
+  else
+    usage
+    exit 1
+  fi
+}
+
 main $@
 exit 0


### PR DESCRIPTION
### :pushpin: References

### :tophat: What is the goal?

- Add --periodicity [PERIOD] --format [FORMAT NAME] --destination [DESTINATION_HOST]

### :memo: How is it being implemented?

I have modified the bash script adding the new params

### :boom: How can it be tested?
See --help
~~~~~~~~~USAGE~~~~~~~~~~~~
./backup_db.sh [NAME]
./backup_db.sh [NAME] --periodicity [PERIOD] --format [FORMAT NAME] --destination 
./backup_db.sh --periodicity [PERIOD] --format [FORMAT NAME] --destination [DESTINATION_HOST]
Valid periods: day-in-week week-in-month month-in-year
Valid formats: custom / plain
Destination: host
Example: ./backup_db.sh --periodicity day-in-week --format custom --destination gva11sucherubi.who.int
If no PERIOD is given, then a manual dump is generated with the timestamp, otherwise the given period is used in the name of the destination file.
