### PR TITLE
Feature/add server error delay and attempts

### DIFF
--- a/DHIS2/cloner/process.py
+++ b/DHIS2/cloner/process.py
@@ -86,7 +86,6 @@ def execute(api, entry, cfg, import_dir):
         debug('No selection.')
         return
 
-
     action = get('action')
     if action == 'activate':
         activate(api, users)
@@ -106,7 +105,7 @@ def execute(api, entry, cfg, import_dir):
         raise ValueError('Unknown action: %s' % action)
 
 
-def wait_for_server(api, delay=90, timeout=900, attempts=2, migration_delay=36000):
+def wait_for_server(api, delay=90, timeout=900, attempts=2, migration_delay=1500):
     "Sleep until server is ready to accept requests"
     debug('Check active API: %s' % api.api_url)
     time.sleep(delay)  # in case tomcat is still starting
@@ -125,7 +124,6 @@ def wait_for_server(api, delay=90, timeout=900, attempts=2, migration_delay=3600
             if time.time() - start_time > timeout:
                 raise RuntimeError('Timeout: could not connect to the API')
             time.sleep(1)
-
 
 
 def select_users(api, usernames, users_from_group_names):


### PR DESCRIPTION
### :pushpin: References
Issue: http://who-dev.essi.upc.edu:8083/issues/2912
Added in the d2-cloner repo: https://github.com/EyeSeeTea/d2-cloner/pull/3

### :tophat: What is the goal?

Avoid crash during the migration to 2.33 when process.py ask for /api/me after relaunch the tomcat with the new war file.


### :memo: How is it being implemented?

I have added attempts and delay in seconds when except requests.exceptions.HTTPError is throw

### :boom: How can it be tested?
run a clone with migration to 2.33 with post-process actions.