### PR TITLE
search_uids.py: Use pg_restore without "-f -"

### DIFF
--- a/DHIS2/database_dumps/search_uids.py
+++ b/DHIS2/database_dumps/search_uids.py
@@ -15,7 +15,7 @@ def main():
     fname = sys.argv[1]
     uids = sys.argv[2:]
 
-    cmd = (['pg_restore', '-f', '-', fname] if fname.endswith('.dump') else
+    cmd = (['pg_restore', fname] if fname.endswith('.dump') else
            ['cat', fname])
 
     print(f'Tables and columns in {fname} where any of the uids appear:')


### PR DESCRIPTION
The reason is that by default it already behaves as if given the option
  -f -
(which redirects to stdout). But some versions of pg_restore do not interpret "-f -" that way and instead create a file called "-".

This change simplifies it and makes it compatible with all versions.