### PR TITLE
Delete one week old WMR Form messages.

### DIFF
--- a/DHIS2/database_manipulation/delete_spam/README.md
+++ b/DHIS2/database_manipulation/delete_spam/README.md
@@ -1,0 +1,52 @@
+# Delete WMR Form message spam
+
+## Description
+
+This folder contains two scripts:
+
+- A python script by default checks for messages older than a week directed to a list of users whose subject contains 'WMR Form monitoring' and deletes them. The subject string and user list can be modified via parameters. These messages arrive in large numbers due to an error in a report.
+
+- A shell script used to run the python script that gets the components necessary for the `dsn` parameter.
+
+## Usage
+
+The `delete_spam.py` script has the following parameters:
+
+- `--uids`: A comma separated list of uids of users that received spam to delete. By default, the ones asked by the client.
+
+- `--subject`:The pattern in the subject of the spam messages. By default, 'WMR Form monitoring%'.
+
+- `--dsn`: String that describes the database connection, its a space separated list of item=value. The items are:
+
+  - `host`: The hostname where the DB is.
+  - `port`: The port where the DB can be reached.
+  - `dbname`: The DB containing the messages.
+  - `user`: The DB user to be used by the script.
+  - `password`: The DB user password.
+
+  By default it has the following value: 'host=localhost dbname=dhishq user=dhishq_usr'.
+
+  Example:
+
+  ```bash
+  $ python3 ./delete_spam.py --dsn "host=localhost port=5432 dbname=dhis2 user=dhis"
+  ```
+
+---
+
+The `run_delete_spam.sh` script has the following parameters:
+
+- `conf_file`: The path to the DHIS2 conf file.
+- `[docker_name]`: If the DHIS2 instance is hosted via docker images, this optional parameter will contain the instance DB docker container name (the name can be viewed via `docker ps`). To get access to the DB a `nc` tunnel will be created from the container internal DB port to the exposed port.
+
+  Example:
+
+  ```bash
+  $ bash ./run_delete_spam.sh "/home/dhis/dhis.conf"
+  ```
+
+  Example for docker DHIS2 instance:
+
+  ```bash
+  $ bash ./run_delete_spam.sh "/home/dhis/dhis.conf" "dhis-2-38-db"
+  ```

--- a/DHIS2/database_manipulation/delete_spam/run_delete_spam.sh
+++ b/DHIS2/database_manipulation/delete_spam/run_delete_spam.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+USAGE="Usage: $(basename "$0") dhisconf_path docker_name"
+
+get_conf_field() {
+    local conf_file=$1 field=$2
+    echo $(grep -e "^$field" "$conf_file" | awk -F '= ' '{print $2}' | tr -d '[:space:]')
+}
+
+parse_dburl() {
+    local url=$1
+
+    local host port dbname
+
+    local pattern="jdbc:postgresql://([^:/]+):([0-9]+)/([^/]+)"
+
+    if [[ $url =~ $pattern ]]; then
+        host="${BASH_REMATCH[1]}"
+        port="${BASH_REMATCH[2]}"
+        dbname="${BASH_REMATCH[3]}"
+
+        echo "$host $port $dbname"
+    fi
+}
+
+delete_spam_tomcat() {
+    local conf_file=$1
+
+    local host port dbname dbuser password
+
+    read -r host port dbname <<<"$(parse_dburl "$(get_conf_field "$conf_file" "connection.url")")"
+    dbuser=$(get_conf_field "$conf_file" "connection.username")
+    password=$(get_conf_field "$conf_file" "connection.password")
+
+    python3 /home/tomcatuser/bin/delete_spam.py --dsn "host=$host port=$port password=$password dbname=$dbname user=$dbuser"
+}
+
+delete_spam_docker() {
+    local conf_file=$1 docker_name=$2
+
+    local docker_id docker_port dburl dbname dbuser
+
+    docker_id=$(docker ps --format "{{.ID}}" --filter "name=$docker_name")
+    docker_port=$(docker port "$docker_id" 1000/tcp | awk -F':' '{print $2}')
+
+    dburl=$(get_conf_field "$conf_file" "connection.url")
+    dbname="${dburl##*/}"
+    dbuser=$(get_conf_field "$conf_file" "connection.username")
+
+    local nc_cmd="nc -lk -p 1000 -e nc localhost 5432"
+
+    docker exec -i "$docker_id" bash -c "$nc_cmd" &
+    local tunel_PID=$!
+
+    python3 ./delete_spam.py --dsn "host=localhost port=$docker_port dbname=$dbname user=$dbuser"
+
+    kill "$tunel_PID"
+    docker exec -i "$docker_id" bash -c "pkill -f "$nc_cmd""
+}
+
+delete_spam() {
+    local conf_file=$1 docker_name=$2
+
+    if [ -n "$docker_name" ]; then
+        delete_spam_docker "$conf_file" "$docker_name"
+    else
+        delete_spam_tomcat "$conf_file"
+    fi
+}
+
+if [ $# -lt 1 ]; then
+    echo "$USAGE"
+    exit 1
+else
+    delete_spam "$@"
+fi


### PR DESCRIPTION
### :pushpin: References

**Issues:**
- [Schedule data approval messages cleaning on a weekly basis](https://app.clickup.com/t/860pzzht9)
- [Schedule user messages cleaning every weeks](https://app.clickup.com/t/865bum5nr)
- [please delete message over a week old in my account and do the same for "chanyc". I thought there was a script to delete old messages](https://app.clickup.com/t/865cmk74b)

### :memo: Implementation
Modified the existing script adding a week old filter for the messages.
List of changes:
- Add a folder for the delete spam scripts.
- Added a README.md describing the scripts and how to use them.
- Added a shell script to run the python script that gets the necessary DB connection parameters.
- Cleaned up and fixed typo in the python script.
- Added a new user to the default user list.
- Added a week old filer to the deleted messages.