### PR TITLE
Add log level option to delete messages script

### DIFF
--- a/DHIS2/database_manipulation/delete_spam/README.md
+++ b/DHIS2/database_manipulation/delete_spam/README.md
@@ -24,7 +24,7 @@ The `delete_spam.py` script has the following parameters:
   - `user`: The DB user to be used by the script.
   - `password`: The DB user password.
 
-- `--log-level`: Choose the script log verbosity level, 0 means no logs, 1 means basic logs and 2 means verbose logs. Defaults to 1.
+- `log-level`: Choose the script log verbosity level, 0 means no logs, 1 means basic logs and 2 means verbose logs. Defaults to 1.
 
   By default it has the following value: 'host=localhost dbname=dhishq user=dhishq_usr'.
 

--- a/DHIS2/database_manipulation/delete_spam/README.md
+++ b/DHIS2/database_manipulation/delete_spam/README.md
@@ -24,6 +24,8 @@ The `delete_spam.py` script has the following parameters:
   - `user`: The DB user to be used by the script.
   - `password`: The DB user password.
 
+- `--log-level`: Choose the script log verbosity level, 0 means no logs, 1 means basic logs and 2 means verbose logs. Defaults to 1.
+
   By default it has the following value: 'host=localhost dbname=dhishq user=dhishq_usr'.
 
   Example:

--- a/DHIS2/database_manipulation/delete_spam/run_delete_spam.sh
+++ b/DHIS2/database_manipulation/delete_spam/run_delete_spam.sh
@@ -63,6 +63,10 @@ delete_spam_docker() {
 delete_spam() {
     local conf_file=$1 docker_name=$2
 
+    local timestamp
+    timestamp=$(date +%Y-%m-%d_%H%M)
+    echo "[$timestamp] Deleting message spam"
+
     if [ -n "$docker_name" ]; then
         delete_spam_docker "$conf_file" "$docker_name"
     else


### PR DESCRIPTION
## Description

Previously this script generated to much log entries, leading to a excessive disc usage.
By adding the `log-level` option its possible to control the amount of logging. If no option is provided the script defaults to a minimalist log like this:

```
[2024-03-13_0700] Deleting message spam
number of messages: 369350
```
