### PR TITLE
Added log notificator

### DIFF
--- a/DHIS2/log_notificator/README.md
+++ b/DHIS2/log_notificator/README.md
@@ -1,0 +1,24 @@
+# Catalina log notificator script
+
+## Description
+
+The script is used to identify the date when an error occurs in the catalina.out log and notify it to the MS Teams channel.
+
+## Usage
+
+It is executed like this:
+
+```bash
+usr/bin/python3 /home/tomcatuser/bin/log_notificator/log_notificator.py /home/tomcatuser/bin/log_notificator/config.json
+```
+
+## Configuration
+
+The config file contains the following fields:
+
+- `"log_path"`: It's the absolute path to catalina.out.
+- `"log_string"`: "Error while sending email: Sending the email to the following server failed", it's the error to search for.
+- `"ms_url"`: It's the URL for sending messages to MS Teams.
+- `"control_file"`: It's the absolute path to the control file (it needs to be created with a touch command).
+- `"notification_script_test"`: It's the absolute path to a Ruby version for testing that the parameters work correctly and to preview them before sending to the Teams channel.
+- `"notification_script_path"`: It's the absolute path to the Ruby script that notifies Teams.

--- a/DHIS2/log_notificator/config.json
+++ b/DHIS2/log_notificator/config.json
@@ -1,0 +1,8 @@
+{
+  "log_path": "",
+  "log_string": "Error while sending email: Sending the email to the following server failed",
+  "ms_url": "",
+  "control_file": "",
+  "notification_script_test": "",
+  "notification_script_path": ""
+}

--- a/DHIS2/log_notificator/log_notificator.py
+++ b/DHIS2/log_notificator/log_notificator.py
@@ -1,0 +1,66 @@
+import argparse
+import datetime
+import json
+import re
+import subprocess
+
+
+def read_last_notified_date(control_file_path):
+    try:
+        with open(control_file_path, 'r') as f:
+            last_timestamp = float(f.read().strip())
+            return datetime.datetime.fromtimestamp(last_timestamp)
+    except (FileNotFoundError, ValueError):
+        return datetime.datetime.min
+
+
+def find_new_errors(log_file_path, log_string, last_notified_date):
+    new_errors = []
+    with open(log_file_path, 'r') as log_file:
+        for line in log_file:
+            if log_string in line:
+                match = re.search(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}', line)
+                if match:
+                    error_date = datetime.datetime.fromisoformat(match.group())
+                    if error_date > last_notified_date:
+                        new_errors.append((error_date, line.strip()))
+    return new_errors
+
+
+def update_control_file(control_file_path, new_last_date):
+    with open(control_file_path, 'w') as f:
+        f.write(str(new_last_date.timestamp()))
+
+
+def notify_new_errors(ms_url, errors, control_file_path, notification_script_path):
+    if errors:
+        for error_date, error_msg in errors:
+            message = f"Error found at {error_date}: {error_msg}"
+            subprocess.run(
+                ['/usr/bin/ruby', notification_script_path, ms_url, message], check=True)
+        update_control_file(control_file_path, errors[-1][0])
+
+
+def main(config_file_path):
+    with open(config_file_path, 'r') as f:
+        config = json.load(f)
+
+    log_file_path = config['log_path']
+    log_string = config['log_string']
+    ms_url = config['ms_url']
+    control_file_path = config['control_file']
+    notification_script_path = config['notification_script_path']
+
+    last_notified_date = read_last_notified_date(control_file_path)
+    new_errors = find_new_errors(log_file_path, log_string, last_notified_date)
+    notify_new_errors(ms_url, new_errors, control_file_path,
+                      notification_script_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Log Notifier Script')
+    parser.add_argument('config_file', type=str,
+                        help='Path to the configuration JSON file')
+    args = parser.parse_args()
+
+    main(args.config_file)

--- a/DHIS2/log_notificator/ms_notification.rb
+++ b/DHIS2/log_notificator/ms_notification.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/ruby
+
+require 'net/https'
+require 'json'
+
+ENV['http_proxy'] = 'http://openproxy.who.int:8080/'
+ENV['https_proxy'] = 'http://openproxy.who.int:8080/'
+uri = URI.parse("#{ARGV[0]}")
+http = Net::HTTP.new(uri.host, uri.port)
+http.use_ssl = true
+request = Net::HTTP::Post.new(uri.request_uri, {'Content-Type' => 'application/json'})
+request.body = {
+    "text"     => "[*NOTIFICATOR LOG* - PROD] - #{ARGV[1]}",
+}.to_json
+response = http.request(request)
+puts response.body

--- a/DHIS2/log_notificator/notification_test.rb
+++ b/DHIS2/log_notificator/notification_test.rb
@@ -1,0 +1,4 @@
+#!/usr/bin/ruby
+
+puts "URL -#{ARGV[0]}"
+puts "[*NOTIFICATOR LOG* - PROD] -#{ARGV[1]}"


### PR DESCRIPTION

The script is used to identify the date when an error occurs in the catalina.out log and notify it to the MS Teams channel. It is executed like this:
usr/bin/python3 /home/tomcatuser/bin/log_notificator/log_notificator.py /home/tomcatuser/bin/log_notificator/config.json

The config file contains the following fields:

"log_path": It's the absolute path to catalina.out.
"log_string": "Error while sending email: Sending the email to the following server failed", it's the error to search for.
"ms_url": It's the URL for sending messages to MS Teams.
"control_file": It's the absolute path to the control file (it needs to be created with a touch command).
"notification_script_test": It's the absolute path to a Ruby version for testing that the parameters work correctly and to preview them before sending to the Teams channel.
"notification_script_path": It's the absolute path to the Ruby script that notifies Teams.