### PR TITLE
Add --exclude-db option to the backup script

### DIFF
--- a/DHIS2/backups/README.md
+++ b/DHIS2/backups/README.md
@@ -8,7 +8,7 @@ Script meant to either be:
 - used with cron to perform periodical backups of a tomcat based DHIS2 instance.
 - launched manually to create a manual backup.
 
-It will make a backup of the database and compress the files from DHIS2 home, excluding the apps, if not skipped via `--exclude-files`.
+It will make a backup of the database and compress the files from DHIS2 home, excluding the apps, if not skipped via `--exclude-db` and/or `--exclude-files`.
 If the `--destination` option is used the backup will also be copied to a remote location.
 
 Backup name is composed by: "BACKUP-`INSTANCE`-`PERIOD`-`NAME`"
@@ -27,6 +27,7 @@ Options:
 - `-f, --format [custom | plain]`: Type of format used in `pg_dump`, custom means `-Fc` and plain means a compressed `-Fp`.
 - `-d, --destination [HOSTNAME]`: The hostname of the remote location where the backup will be copied.
 - `-n, --name [NAME]`: Custom name for `NAME` slot, if empty and not a periodic backup will default to "MANUAL".
+- `--exclude-db`: Exclude the database dump from the backup.
 - `--exclude-audit`: Exclude audit table.
 - `--exclude-files`: Exclude the DHIS2 files from the backup.
 
@@ -35,6 +36,11 @@ Options:
 Backup with custom name and excluding DHIS2 files:
 ```bash
 bash /path/to/backup_tomcat_instance.sh --name TEST --exclude-files
+```
+
+Backup files only with custom name:
+```bash
+bash /path/to/backup_tomcat_instance.sh --name TEST --exclude-db
 ```
 
 Backup with periodicity, excluding audit table and remote copy:

--- a/DHIS2/backups/backup_tomcat_instance.sh
+++ b/DHIS2/backups/backup_tomcat_instance.sh
@@ -257,8 +257,9 @@ backup_db() {
 
 copy_backup_to_remote() {
     local db_backup_file=$1 files_backup_file=$2
-    local db_path="${dump_dest_path}/${db_backup_file}" files_path
-    local dump_remote_dest_path="${dump_remote_dest_path}/${dhis2_instance}"
+    local db_path="${dump_dest_path}/${db_backup_file}"
+    local files_path="${dump_dest_path}/${files_backup_file}"
+    local dump_remote_dest_path="${dump_remote_dest_path}/."
 
     if [ -z "$db_backup_file" ] && [ -z "$files_backup_file" ]; then
         error "[$(get_timestamp)] No backup files to copy."

--- a/DHIS2/backups/backup_tomcat_instance.sh
+++ b/DHIS2/backups/backup_tomcat_instance.sh
@@ -241,14 +241,23 @@ backup_db() {
 }
 
 copy_backup_to_remote() {
-    local db_backup_file=$1 file_backup_file=$2
+    local db_backup_file=$1 files_backup_file=$2
     local db_path="${dump_dest_path}/${db_backup_file}" files_path
+    local dump_remote_dest_path="${dump_remote_dest_path}/${dhis2_instance}"
 
-    echo "[$(get_timestamp)] CP backup into ${DB_REMOTE_DEST_SERVER}..."
-    if [ -n "$file_backup_file" ]; then
-        files_path="${dump_dest_path}/${file_backup_file}"
+    if [ -z "$db_backup_file" ] && [ -z "$files_backup_file" ]; then
+        error "[$(get_timestamp)] No backup files to copy."
+        return 1
+    fi
+
+    if [ -n "$files_backup_file" ] && [ -n "$db_backup_file" ]; then
+        echo "[$(get_timestamp)] copy DB and files backup into ${DB_REMOTE_DEST_SERVER}..."
         scp "${db_path}" "${files_path}" "${DB_REMOTE_DEST_SERVER}:${dump_remote_dest_path}"
-    else
+    elif [ -n "$files_backup_file" ]; then
+        echo "[$(get_timestamp)] copy files backup into ${DB_REMOTE_DEST_SERVER}..."
+        scp "${files_path}" "${DB_REMOTE_DEST_SERVER}:${dump_remote_dest_path}"
+    elif [ -n "$db_backup_file" ]; then
+        echo "[$(get_timestamp)] copy DB backup into ${DB_REMOTE_DEST_SERVER}..."
         scp "${db_path}" "${DB_REMOTE_DEST_SERVER}:${dump_remote_dest_path}"
     fi
 }

--- a/DHIS2/backups/backup_tomcat_instance.sh
+++ b/DHIS2/backups/backup_tomcat_instance.sh
@@ -180,6 +180,15 @@ process_options() {
         esac
 
     done
+
+    if [ "$SKIP_DB" -eq 1 ] && [ "$SKIP_FILES" -eq 1 ]; then
+        error "[$(get_timestamp)] The options --exclude-db and --exclude-files are mutually exclusive."
+        exit 1
+    fi
+
+    if [ "$SKIP_DB" -eq 1 ] && [ "$SKIP_AUDIT" -eq 1 ]; then
+        echo "[$(get_timestamp)] The option --exclude-audit is not applicable when --exclude-db is set."
+    fi
 }
 
 assign_name() {

--- a/DHIS2/backups/backup_tomcat_instance.sh
+++ b/DHIS2/backups/backup_tomcat_instance.sh
@@ -209,13 +209,19 @@ fail() {
 
 backup_dhis2_folders() {
     local dhis2_home=$1 backup_file_base=$2
-    local backup_file
+    local backup_file tar_folders
 
     backup_file="${backup_file_base}_dhis2_files.tar.gz"
     FILES_BACKUP_FILE="${backup_file}"
 
+    if [[ -d "static" ]]; then
+        tar_folders=("files" "static")
+    else
+        tar_folders=("files")
+    fi
+
     echo "[$(get_timestamp)] Generating DHIS2 files backup into ${backup_file}..."
-    tar --exclude="files/apps" -C "${dhis2_home}" -czf "${dump_dest_path}/${backup_file}" "files" "static"
+    tar --exclude="files/apps" -C "${dhis2_home}" -chzf "${dump_dest_path}/${backup_file}" "${tar_folders[@]}"
 }
 
 backup_db() {


### PR DESCRIPTION
## Description

Added `--exclude-db` to the script to work with the new setup of PROD-INDIV.

### 28/05 Update
- Fixed copy_backup_to_remote attempting to copy the DB backup with the `--exclude-db`
- Add check for incompatible options (`--exclude-db` and `--exclude-files` or `--exclude-audit` and `--exclude-db`)