### PR TITLE
Add RAM sentinel daemon for OOM prevention

### DIFF
--- a/monitoring/ram_sentinel/README.md
+++ b/monitoring/ram_sentinel/README.md
@@ -22,6 +22,7 @@ A daemon that monitors available RAM and stops Monit-managed services when memor
 
 ```
 ram_sentinel.py --emergency-trigger MB --safe-recovery MB --tier TYPE:MONIT_NAME [--tier ...] [--dry-run]
+               [--notify-script PATH] [--server-name NAME] [--notify-level critical|all]
 ```
 
 ### Parameters
@@ -32,6 +33,21 @@ ram_sentinel.py --emergency-trigger MB --safe-recovery MB --tier TYPE:MONIT_NAME
 | `--safe-recovery MB` | yes | Available RAM (MB) required before restoring services |
 | `--tier TYPE:MONIT_NAME` | yes (repeat) | Service to stop, in escalation order |
 | `--dry-run` | no | Simulate all actions — reads RAM and PIDs for real, skips destructive commands |
+| `--notify-script PATH` | no | Path to the centralized notification script (disabled if omitted) |
+| `--server-name NAME` | no | Server label sent as `MONIT_HOST` in notifications (defaults to hostname) |
+| `--notify-level` | no | `critical` (default): only kill/stop events. `all`: also recovery events. |
+
+## Notifications
+
+When `--notify-script` is set, the sentinel calls the script via `subprocess.run()` on each kill/stop action and (if `--notify-level all`) on recovery. The script receives the event details through environment variables:
+
+| Variable | Value |
+|----------|-------|
+| `MONIT_HOST` | `--server-name` value (or hostname) |
+| `MONIT_SERVICE` | `RAM-SENTINEL` |
+| `MONIT_DESCRIPTION` | `[CRITICAL] ...` or `[INFO] ...` |
+
+This matches the calling convention of `monit_clickup_notifications.py` so no proxy/HTTP logic needs to be duplicated in the sentinel.
 
 ## Dry-run mode
 
@@ -66,7 +82,10 @@ ExecStart=/usr/bin/python3 /usr/local/bin/ram_sentinel.py \
   --emergency-trigger 4000 \
   --safe-recovery 8000 \
   --tier kill:my_tomcat_service \
-  --tier stop:my_postgres_service
+  --tier stop:my_postgres_service \
+  --notify-script /path/to/notification_script.py \
+  --server-name my-server \
+  --notify-level critical
 ```
 
 Set thresholds based on your server's total RAM. A reasonable rule of thumb:

--- a/monitoring/ram_sentinel/README.md
+++ b/monitoring/ram_sentinel/README.md
@@ -1,0 +1,100 @@
+# RAM Sentinel
+
+A daemon that monitors available RAM and stops Monit-managed services when memory drops critically low, then restores them once RAM recovers. Designed to prevent OOM kills on servers running Java/Tomcat and PostgreSQL.
+
+## How it works
+
+1. Polls available RAM every 2 seconds via `free -m`.
+2. When RAM drops below `--emergency-trigger`, stops services in the order defined by `--tier`.
+3. Waits up to 20 seconds after each tier for RAM to settle before escalating to the next one.
+4. Once all necessary services are stopped, waits for RAM to reach `--safe-recovery`.
+5. Restores services in reverse order by handing them back to Monit (`monit monitor`).
+6. Persists state to `/run/stopram/state.json` so an interrupted recovery is resumed on restart.
+
+## Tier types
+
+| Type | Behaviour |
+|------|-----------|
+| `kill` | Reads the PID from `monit status`, unmonitors the service, then sends SIGKILL. Fast — use for Java/Tomcat. |
+| `stop` | Unmonitors the service, then runs `monit stop`. Clean shutdown — use for PostgreSQL or any service with a stop program defined in monitrc. |
+
+## Usage
+
+```
+ram_sentinel.py --emergency-trigger MB --safe-recovery MB --tier TYPE:MONIT_NAME [--tier ...] [--dry-run]
+```
+
+### Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--emergency-trigger MB` | yes | Available RAM (MB) that triggers emergency actions |
+| `--safe-recovery MB` | yes | Available RAM (MB) required before restoring services |
+| `--tier TYPE:MONIT_NAME` | yes (repeat) | Service to stop, in escalation order |
+| `--dry-run` | no | Simulate all actions — reads RAM and PIDs for real, skips destructive commands |
+
+## Dry-run mode
+
+Use `--dry-run` to validate config before deploying:
+
+```bash
+python3 ram_sentinel.py \
+  --emergency-trigger 4000 \
+  --safe-recovery 8000 \
+  --tier kill:my_tomcat_service \
+  --tier stop:my_postgres_service \
+  --dry-run
+```
+
+Since nothing actually stops, RAM never recovers — the sentinel cycles repeatedly. Ctrl-C when satisfied. This validates argument parsing, Monit name resolution, and PID reads, but not the actual stop/restore flow.
+
+## Deployment
+
+### 1. Copy the script
+
+```bash
+cp ram_sentinel.py /usr/local/bin/ram_sentinel.py
+chmod +x /usr/local/bin/ram_sentinel.py
+```
+
+### 2. Create the systemd service
+
+Copy `ram_sentinel_example.service` to `/etc/systemd/system/ram-sentinel.service` and adjust the `ExecStart` line for your environment:
+
+```ini
+ExecStart=/usr/bin/python3 /usr/local/bin/ram_sentinel.py \
+  --emergency-trigger 4000 \
+  --safe-recovery 8000 \
+  --tier kill:my_tomcat_service \
+  --tier stop:my_postgres_service
+```
+
+Set thresholds based on your server's total RAM. A reasonable rule of thumb:
+- `--emergency-trigger`: ~12–15% of total RAM
+- `--safe-recovery`: ~25–30% of total RAM
+
+### 3. Enable and start
+
+```bash
+systemctl daemon-reload
+systemctl enable ram-sentinel
+systemctl start ram-sentinel
+journalctl -u ram-sentinel -f
+```
+
+## Verifying Monit service names
+
+Service names passed to `--tier` must match exactly what `monit summary` shows:
+
+```bash
+monit summary
+```
+
+At startup, the sentinel logs a WARNING for any tier name not found in Monit — check `journalctl -u ram-sentinel` after the first start.
+
+## Prerequisites
+
+- Python 3
+- Monit running and managing the target services
+- Services must have a `stop program` defined in monitrc to use the `stop` tier type
+- Root privileges (required for SIGKILL and monit commands)

--- a/monitoring/ram_sentinel/ram_sentinel.py
+++ b/monitoring/ram_sentinel/ram_sentinel.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import subprocess
+import time
+from datetime import datetime
+
+# === CONSTANTS (same across all environments) ===
+CHECK_INTERVAL_SECONDS = 2
+RECOVERY_LOG_INTERVAL_SECONDS = 30
+STOP_TIMEOUT_SECONDS = 30
+# How long to wait for RAM to settle after stopping a tier before escalating
+SETTLE_SECONDS = 20
+STATE_FILE = "/run/stopram/state.json"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "RAM Sentinel: stops services managed by Monit when available RAM "
+            "drops critically low. Services are stopped in --tier order and "
+            "restored in reverse order once RAM recovers."
+        )
+    )
+    parser.add_argument(
+        "--emergency-trigger",
+        type=int,
+        required=True,
+        metavar="MB",
+        help="Available RAM (MB) that triggers emergency actions",
+    )
+    parser.add_argument(
+        "--safe-recovery",
+        type=int,
+        required=True,
+        metavar="MB",
+        help="Available RAM (MB) required before handing services back to Monit",
+    )
+    parser.add_argument(
+        "--tier",
+        action="append",
+        dest="tiers",
+        metavar="TYPE:MONIT_NAME",
+        help=(
+            "Service to stop, in escalation order. Format: TYPE:MONIT_NAME. "
+            "TYPE must be 'kill' (SIGKILL the monitored PID) or "
+            "'stop' (monit stop — uses the service's stop program). "
+            "Repeat --tier for multiple services. Example: "
+            "--tier kill:dhis_tomcat --tier stop:postgres"
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Simulate all actions without executing them. Reads RAM, Monit status "
+            "and PIDs for real — only skips the destructive commands "
+            "(unmonitor, kill, stop, monitor)."
+        ),
+    )
+    cfg = parser.parse_args()
+
+    if not cfg.tiers:
+        parser.error("At least one --tier is required.")
+
+    cfg.tiers = [_parse_tier(t, parser) for t in cfg.tiers]
+    return cfg
+
+
+def _parse_tier(raw, parser):
+    parts = raw.split(":", 1)
+    if len(parts) != 2:
+        parser.error(f"Invalid --tier format '{raw}'. Expected TYPE:MONIT_NAME.")
+    tier_type, monit_name = parts
+    if tier_type not in ("kill", "stop"):
+        parser.error(f"Unknown tier type '{tier_type}'. Must be 'kill' or 'stop'.")
+    if not monit_name:
+        parser.error(f"Missing monit name in --tier '{raw}'.")
+    return {"type": tier_type, "name": monit_name}
+
+
+def info(message):
+    timestamp = datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
+    print(f"{timestamp} {message}", flush=True)
+
+
+def run_cmd(cmd, shell=False, timeout=None):
+    try:
+        if isinstance(cmd, str) and not shell:
+            cmd = cmd.split()
+        return subprocess.check_output(
+            cmd, shell=shell, text=True, timeout=timeout
+        ).strip()
+    except subprocess.TimeoutExpired:
+        info(f"WARNING: command timed out after {timeout}s: {cmd}")
+        return None
+    except subprocess.CalledProcessError as e:
+        info(f"Error executing '{cmd}': {e}")
+        return None
+
+
+def get_available_memory_mb():
+    try:
+        output = run_cmd("free -m")
+        if output:
+            for line in output.split("\n"):
+                if line.startswith("Mem:"):
+                    parts = line.split()
+                    return int(parts[6])
+    except Exception as e:
+        info(f"Failed to query available memory: {e}")
+    return 0
+
+
+def get_monit_names():
+    """Returns the set of service names known to Monit."""
+    output = run_cmd("monit summary -B") or run_cmd("monit summary")
+    if not output:
+        return set()
+    names = set()
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 2:
+            # Cover both formats: 'name status ...' and "Process 'name' status ..."
+            names.add(parts[0].strip("'\""))
+            names.add(parts[1].strip("'\""))
+    return names
+
+
+def validate_tiers(tiers):
+    """Logs a WARNING for any tier whose monit name is not in 'monit summary'.
+    Keeps running — a misconfigured tier should not leave the host unprotected."""
+    known = get_monit_names()
+    if not known:
+        info("WARNING: could not retrieve Monit service list — skipping tier validation.")
+        return
+    for tier in tiers:
+        if tier["name"] not in known:
+            info(
+                f"WARNING: tier '{tier['type']}:{tier['name']}' — "
+                f"'{tier['name']}' not found in 'monit summary'. "
+                f"Check the service name or update --tier."
+            )
+
+
+def get_monit_pid(monit_name):
+    """Returns the PID reported by Monit for a service, or None."""
+    output = run_cmd(f"monit status {monit_name}")
+    if not output:
+        return None
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("pid"):
+            parts = stripped.split()
+            if len(parts) >= 2 and parts[1].isdigit():
+                return int(parts[1])
+    return None
+
+
+def pid_is_alive(pid):
+    return os.path.exists(f"/proc/{pid}")
+
+
+def wait_for_ram_settle(threshold_mb, max_seconds=SETTLE_SECONDS):
+    """Polls RAM for up to max_seconds. Returns available RAM when stable or timeout."""
+    deadline = time.monotonic() + max_seconds
+    while time.monotonic() < deadline:
+        ram = get_available_memory_mb()
+        if ram > 0 and ram >= threshold_mb:
+            return ram
+        time.sleep(CHECK_INTERVAL_SECONDS)
+    return get_available_memory_mb()
+
+
+def log_system_snapshot():
+    try:
+        snapshot = run_cmd("free -m")
+        info(f"Memory snapshot (free -m):\n{snapshot}")
+        top_procs = run_cmd(
+            "ps -eo pid,%mem,rss,comm --sort=-%mem | head -11", shell=True
+        )
+        info(f"Top processes by memory:\n{top_procs}")
+    except Exception as e:
+        info(f"WARNING: system snapshot failed (non-fatal): {e}")
+
+
+def stop_tier(tier, dry_run=False):
+    """Stops a single tier. Returns the monit name."""
+    name = tier["name"]
+    tier_type = tier["type"]
+
+    if tier_type == "kill":
+        # Read PID before unmonitoring — monit status is unreliable after unmonitor
+        pid = get_monit_pid(name)
+        if pid is None:
+            info(
+                f"Tier kill:{name} — no PID found in monit status. "
+                f"Process may already be dead. Unmonitoring anyway."
+            )
+        elif not pid_is_alive(pid):
+            info(
+                f"Tier kill:{name} — PID {pid} no longer alive. Unmonitoring anyway."
+            )
+            pid = None
+        else:
+            info(f"Tier kill:{name} — PID {pid} found and alive.")
+
+        info(f"Tier kill:{name} — unmonitoring...")
+        maybe_run(f"monit unmonitor {name}", dry_run)
+
+        if pid is not None:
+            info(f"Tier kill:{name} — sending SIGKILL to PID {pid}...")
+            if dry_run:
+                info(f"[DRY-RUN] would os.kill({pid}, 9)")
+            else:
+                try:
+                    os.kill(pid, 9)
+                    info(f"Tier kill:{name} — PID {pid} killed.")
+                except Exception as e:
+                    info(f"Tier kill:{name} — SIGKILL failed: {e}")
+
+    elif tier_type == "stop":
+        info(f"Tier stop:{name} — unmonitoring...")
+        maybe_run(f"monit unmonitor {name}", dry_run)
+        info(f"Tier stop:{name} — running monit stop...")
+        maybe_run(f"monit stop {name}", dry_run, timeout=STOP_TIMEOUT_SECONDS)
+
+    if dry_run:
+        info(f"[DRY-RUN] would sleep 3s for OS to reclaim memory.")
+    else:
+        time.sleep(3)
+
+    return name
+
+
+def save_state(stopped_names, dry_run=False):
+    if dry_run:
+        info(f"[DRY-RUN] would persist state: {stopped_names}")
+        return
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+        tmp_file = STATE_FILE + ".tmp"
+        with open(tmp_file, "w") as f:
+            json.dump(
+                {
+                    "stopped_services": stopped_names,
+                    "timestamp": datetime.now().isoformat(),
+                },
+                f,
+            )
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_file, STATE_FILE)
+    except Exception as e:
+        info(f"WARNING: failed to write state file {STATE_FILE}: {e}")
+
+
+def load_state():
+    try:
+        with open(STATE_FILE) as f:
+            return json.load(f).get("stopped_services", [])
+    except FileNotFoundError:
+        return []
+    except Exception as e:
+        info(f"WARNING: failed to read state file {STATE_FILE}: {e}")
+        return []
+
+
+def clear_state():
+    try:
+        os.remove(STATE_FILE)
+    except FileNotFoundError:
+        pass
+    except Exception as e:
+        info(f"WARNING: failed to remove state file {STATE_FILE}: {e}")
+
+
+def maybe_run(cmd, dry_run, shell=False, timeout=None):
+    """Runs cmd unless dry_run is True, in which case just logs it."""
+    if dry_run:
+        info(f"[DRY-RUN] would run: {cmd}")
+        return None
+    return run_cmd(cmd, shell=shell, timeout=timeout)
+
+
+def enable_monit_service(name, dry_run=False):
+    info(f"Re-enabling Monit tracking for '{name}'...")
+    maybe_run(f"monit monitor {name}", dry_run)
+
+
+def stop_tier_and_settle(cfg, tier, stopped_names):
+    """Stops a tier, persists state, waits for RAM to settle. Returns updated available RAM."""
+    name = tier["name"]
+
+    save_state(stopped_names + [name], dry_run=cfg.dry_run)
+    stop_tier(tier, dry_run=cfg.dry_run)
+    stopped_names.append(name)
+    save_state(stopped_names, dry_run=cfg.dry_run)
+
+    info(f"Waiting up to {SETTLE_SECONDS}s for RAM to settle after stopping '{name}'...")
+    if cfg.dry_run:
+        available_ram = get_available_memory_mb()
+    else:
+        available_ram = wait_for_ram_settle(cfg.emergency_trigger)
+    info(f"Available RAM after stopping '{name}': {available_ram} MB.")
+    return available_ram
+
+
+def run_recovery_routine(cfg):
+    available_ram = get_available_memory_mb()
+    info(
+        f"CRITICAL ALERT: Available RAM ({available_ram} MB) < "
+        f"Emergency Threshold ({cfg.emergency_trigger} MB)!"
+    )
+
+    log_system_snapshot()
+
+    stopped_names = []
+
+    for tier in cfg.tiers:
+        available_ram = stop_tier_and_settle(cfg, tier, stopped_names)
+        if available_ram > 0 and available_ram >= cfg.emergency_trigger:
+            break
+
+    wait_and_restore(cfg, stopped_names)
+
+
+def wait_and_restore(cfg, stopped_names):
+    remaining_tiers = [t for t in cfg.tiers if t["name"] not in stopped_names]
+
+    available_ram = get_available_memory_mb()
+    last_log = 0.0
+
+    while available_ram < cfg.safe_recovery:
+        if 0 < available_ram < cfg.emergency_trigger and remaining_tiers:
+            tier = remaining_tiers.pop(0)
+            info(
+                f"RAM still critical ({available_ram} MB). "
+                f"Escalating to next tier: {tier['type']}:{tier['name']}..."
+            )
+            available_ram = stop_tier_and_settle(cfg, tier, stopped_names)
+            continue
+
+        now = time.monotonic()
+        if now - last_log >= RECOVERY_LOG_INTERVAL_SECONDS:
+            info(
+                f"Waiting for recovery: {available_ram} MB available "
+                f"(target: >= {cfg.safe_recovery} MB, stopped: {stopped_names})"
+            )
+            last_log = now
+
+        time.sleep(CHECK_INTERVAL_SECONDS)
+        available_ram = get_available_memory_mb()
+
+    info(
+        f"RAM recovered: {available_ram} MB (>= {cfg.safe_recovery} MB). "
+        f"Restoring services in reverse order: {list(reversed(stopped_names))}"
+    )
+    for name in reversed(stopped_names):
+        enable_monit_service(name, dry_run=cfg.dry_run)
+    if cfg.dry_run:
+        info("[DRY-RUN] would clear state file.")
+    else:
+        clear_state()
+
+    info("Emergency recovery completed. Monit will restart the services.")
+
+
+def main():
+    cfg = parse_args()
+
+    tier_summary = ", ".join(f"{t['type']}:{t['name']}" for t in cfg.tiers)
+    mode = "DRY-RUN (no destructive actions will be taken)" if cfg.dry_run else "LIVE"
+    info(
+        f"RAM Sentinel started [{mode}] | "
+        f"Interval: {CHECK_INTERVAL_SECONDS}s | "
+        f"Emergency Trigger: < {cfg.emergency_trigger} MB | "
+        f"Safe Target: >= {cfg.safe_recovery} MB | "
+        f"Tiers: [{tier_summary}]"
+    )
+
+    try:
+        os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
+    except Exception as e:
+        info(f"WARNING: cannot create state dir for {STATE_FILE}: {e}")
+
+    validate_tiers(cfg.tiers)
+
+    # Resume an interrupted recovery (skipped in dry-run: state file is live-mode-only)
+    if cfg.dry_run:
+        info("[DRY-RUN] skipping state file load.")
+    else:
+        pending = load_state()
+        if pending:
+            info(f"Found pending state from a previous run: {pending}. Resuming recovery...")
+            wait_and_restore(cfg, pending)
+
+    while True:
+        try:
+            available_ram = get_available_memory_mb()
+            if 0 < available_ram < cfg.emergency_trigger:
+                run_recovery_routine(cfg)
+        except Exception as e:
+            info(f"Unexpected error in sentinel loop: {e}")
+
+        time.sleep(CHECK_INTERVAL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring/ram_sentinel/ram_sentinel.py
+++ b/monitoring/ram_sentinel/ram_sentinel.py
@@ -15,13 +15,18 @@ STOP_TIMEOUT_SECONDS = 30
 SETTLE_SECONDS = 20
 STATE_FILE = "/run/stopram/state.json"
 
+# === NOTIFICATION (populated from CLI args) ===
+# "critical" fires on kill/stop actions; "info" also fires on recovery.
+_NOTIFY_SCRIPT = ""
+_NOTIFY_SERVER_NAME = ""
+_NOTIFY_LEVEL = "critical"
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "RAM Sentinel: stops services managed by Monit when available RAM "
-            "drops critically low. Services are stopped in --tier order and "
-            "restored in reverse order once RAM recovers."
+            "RAM Sentinel: stops services when available RAM drops critically low. "
+            "Services are stopped in --tier order and restored in reverse order once RAM recovers."
         )
     )
     parser.add_argument(
@@ -36,13 +41,13 @@ def parse_args():
         type=int,
         required=True,
         metavar="MB",
-        help="Available RAM (MB) required before handing services back to Monit",
+        help="Available RAM (MB) required before restoring services",
     )
     parser.add_argument(
         "--tier",
         action="append",
         dest="tiers",
-        metavar="TYPE:MONIT_NAME",
+        metavar="TYPE:NAME",
         help=(
             "Service to stop, in escalation order. Format: TYPE:MONIT_NAME. "
             "TYPE must be 'kill' (SIGKILL the monitored PID) or "
@@ -56,10 +61,28 @@ def parse_args():
         action="store_true",
         help=(
             "Simulate all actions without executing them. Reads RAM, Monit status "
-            "and PIDs for real — only skips the destructive commands "
-            "(unmonitor, kill, stop, monitor)."
+            "and PIDs for real — only skips the destructive commands."
         ),
     )
+    parser.add_argument(
+        "--notify-script",
+        default="",
+        metavar="PATH",
+        help="Path to the centralized notification script (empty = disabled)",
+    )
+    parser.add_argument(
+        "--server-name",
+        default="",
+        metavar="NAME",
+        help="Server label used as MONIT_HOST in notifications (defaults to hostname)",
+    )
+    parser.add_argument(
+        "--notify-level",
+        choices=["critical", "all"],
+        default="critical",
+        help="'critical': only kill/stop events (default). 'all': also recovery events.",
+    )
+
     cfg = parser.parse_args()
 
     if not cfg.tiers:
@@ -72,18 +95,40 @@ def parse_args():
 def _parse_tier(raw, parser):
     parts = raw.split(":", 1)
     if len(parts) != 2:
-        parser.error(f"Invalid --tier format '{raw}'. Expected TYPE:MONIT_NAME.")
-    tier_type, monit_name = parts
+        parser.error(f"Invalid --tier format '{raw}'. Expected TYPE:NAME.")
+    tier_type, name = parts
     if tier_type not in ("kill", "stop"):
         parser.error(f"Unknown tier type '{tier_type}'. Must be 'kill' or 'stop'.")
-    if not monit_name:
-        parser.error(f"Missing monit name in --tier '{raw}'.")
-    return {"type": tier_type, "name": monit_name}
+    if not name:
+        parser.error(f"Missing name in --tier '{raw}'.")
+    return {"type": tier_type, "name": name}
 
 
 def info(message):
     timestamp = datetime.now().strftime("[%Y-%m-%d %H:%M:%S]")
     print(f"{timestamp} {message}", flush=True)
+
+
+def notify(description, level="critical"):
+    """Calls the centralized notification script with MONIT_* env vars, non-fatal.
+    level='critical' always fires; level='info' only fires when --notify-level all."""
+    if not _NOTIFY_SCRIPT:
+        return
+    if level == "info" and _NOTIFY_LEVEL != "all":
+        return
+    try:
+        env = os.environ.copy()
+        env["MONIT_HOST"] = _NOTIFY_SERVER_NAME
+        env["MONIT_SERVICE"] = "RAM-SENTINEL"
+        env["MONIT_DESCRIPTION"] = f"[{level.upper()}] {description}"
+        subprocess.run(
+            ["python3", _NOTIFY_SCRIPT],
+            env=env,
+            timeout=15,
+            capture_output=True,
+        )
+    except Exception as e:
+        info(f"WARNING: notification failed (non-fatal): {e}")
 
 
 def run_cmd(cmd, shell=False, timeout=None):
@@ -123,20 +168,22 @@ def get_monit_names():
     for line in output.splitlines():
         parts = line.split()
         if len(parts) >= 2:
-            # Cover both formats: 'name status ...' and "Process 'name' status ..."
             names.add(parts[0].strip("'\""))
             names.add(parts[1].strip("'\""))
     return names
 
 
 def validate_tiers(tiers):
-    """Logs a WARNING for any tier whose monit name is not in 'monit summary'.
-    Keeps running — a misconfigured tier should not leave the host unprotected."""
+    """Logs a WARNING for misconfigured tiers. Never aborts — a bad tier should not
+    leave the host unprotected."""
+    monit_tiers = tiers
+    if not monit_tiers:
+        return
     known = get_monit_names()
     if not known:
-        info("WARNING: could not retrieve Monit service list — skipping tier validation.")
+        info("WARNING: could not retrieve Monit service list — skipping Monit tier validation.")
         return
-    for tier in tiers:
+    for tier in monit_tiers:
         if tier["name"] not in known:
             info(
                 f"WARNING: tier '{tier['type']}:{tier['name']}' — "
@@ -187,22 +234,16 @@ def log_system_snapshot():
 
 
 def stop_tier(tier, dry_run=False):
-    """Stops a single tier. Returns the monit name."""
+    """Stops a single tier."""
     name = tier["name"]
     tier_type = tier["type"]
 
     if tier_type == "kill":
-        # Read PID before unmonitoring — monit status is unreliable after unmonitor
         pid = get_monit_pid(name)
         if pid is None:
-            info(
-                f"Tier kill:{name} — no PID found in monit status. "
-                f"Process may already be dead. Unmonitoring anyway."
-            )
+            info(f"Tier kill:{name} — no PID found in monit status. Unmonitoring anyway.")
         elif not pid_is_alive(pid):
-            info(
-                f"Tier kill:{name} — PID {pid} no longer alive. Unmonitoring anyway."
-            )
+            info(f"Tier kill:{name} — PID {pid} no longer alive. Unmonitoring anyway.")
             pid = None
         else:
             info(f"Tier kill:{name} — PID {pid} found and alive.")
@@ -232,12 +273,17 @@ def stop_tier(tier, dry_run=False):
     else:
         time.sleep(3)
 
-    return name
+
+def restore_tier(tier, dry_run=False):
+    """Re-enables Monit tracking so Monit restarts the service."""
+    name = tier["name"]
+    info(f"Re-enabling Monit tracking for '{name}'...")
+    maybe_run(f"monit monitor {name}", dry_run)
 
 
-def save_state(stopped_names, dry_run=False):
+def save_state(stopped_tiers, dry_run=False):
     if dry_run:
-        info(f"[DRY-RUN] would persist state: {stopped_names}")
+        info(f"[DRY-RUN] would persist state: {[t['type']+':'+t['name'] for t in stopped_tiers]}")
         return
     try:
         os.makedirs(os.path.dirname(STATE_FILE), exist_ok=True)
@@ -245,7 +291,7 @@ def save_state(stopped_names, dry_run=False):
         with open(tmp_file, "w") as f:
             json.dump(
                 {
-                    "stopped_services": stopped_names,
+                    "stopped_tiers": stopped_tiers,
                     "timestamp": datetime.now().isoformat(),
                 },
                 f,
@@ -260,7 +306,12 @@ def save_state(stopped_names, dry_run=False):
 def load_state():
     try:
         with open(STATE_FILE) as f:
-            return json.load(f).get("stopped_services", [])
+            data = json.load(f)
+        # New format: list of {"type": ..., "name": ...} dicts
+        if "stopped_tiers" in data:
+            return data["stopped_tiers"]
+        # Old format: list of name strings under "stopped_services"
+        return [{"type": "stop", "name": n} for n in data.get("stopped_services", [])]
     except FileNotFoundError:
         return []
     except Exception as e:
@@ -285,19 +336,22 @@ def maybe_run(cmd, dry_run, shell=False, timeout=None):
     return run_cmd(cmd, shell=shell, timeout=timeout)
 
 
-def enable_monit_service(name, dry_run=False):
-    info(f"Re-enabling Monit tracking for '{name}'...")
-    maybe_run(f"monit monitor {name}", dry_run)
-
-
-def stop_tier_and_settle(cfg, tier, stopped_names):
+def stop_tier_and_settle(cfg, tier, stopped_tiers, trigger_ram=None):
     """Stops a tier, persists state, waits for RAM to settle. Returns updated available RAM."""
     name = tier["name"]
 
-    save_state(stopped_names + [name], dry_run=cfg.dry_run)
+    save_state(stopped_tiers + [tier], dry_run=cfg.dry_run)
     stop_tier(tier, dry_run=cfg.dry_run)
-    stopped_names.append(name)
-    save_state(stopped_names, dry_run=cfg.dry_run)
+    stopped_tiers.append(tier)
+    save_state(stopped_tiers, dry_run=cfg.dry_run)
+
+    ram_after = get_available_memory_mb()
+    ram_info = (
+        f"RAM at trigger: {trigger_ram} MB → after stop: {ram_after} MB."
+        if trigger_ram is not None
+        else f"RAM after stop: {ram_after} MB."
+    )
+    notify(f"{tier['type'].upper()} {name}: service stopped. {ram_info}")
 
     info(f"Waiting up to {SETTLE_SECONDS}s for RAM to settle after stopping '{name}'...")
     if cfg.dry_run:
@@ -314,20 +368,20 @@ def run_recovery_routine(cfg):
         f"CRITICAL ALERT: Available RAM ({available_ram} MB) < "
         f"Emergency Threshold ({cfg.emergency_trigger} MB)!"
     )
-
     log_system_snapshot()
 
-    stopped_names = []
+    stopped_tiers = []
 
     for tier in cfg.tiers:
-        available_ram = stop_tier_and_settle(cfg, tier, stopped_names)
+        available_ram = stop_tier_and_settle(cfg, tier, stopped_tiers, trigger_ram=available_ram)
         if available_ram > 0 and available_ram >= cfg.emergency_trigger:
             break
 
-    wait_and_restore(cfg, stopped_names)
+    wait_and_restore(cfg, stopped_tiers)
 
 
-def wait_and_restore(cfg, stopped_names):
+def wait_and_restore(cfg, stopped_tiers):
+    stopped_names = {t["name"] for t in stopped_tiers}
     remaining_tiers = [t for t in cfg.tiers if t["name"] not in stopped_names]
 
     available_ram = get_available_memory_mb()
@@ -340,45 +394,59 @@ def wait_and_restore(cfg, stopped_names):
                 f"RAM still critical ({available_ram} MB). "
                 f"Escalating to next tier: {tier['type']}:{tier['name']}..."
             )
-            available_ram = stop_tier_and_settle(cfg, tier, stopped_names)
+            available_ram = stop_tier_and_settle(cfg, tier, stopped_tiers, trigger_ram=available_ram)
+            stopped_names.add(tier["name"])
             continue
 
         now = time.monotonic()
         if now - last_log >= RECOVERY_LOG_INTERVAL_SECONDS:
             info(
                 f"Waiting for recovery: {available_ram} MB available "
-                f"(target: >= {cfg.safe_recovery} MB, stopped: {stopped_names})"
+                f"(target: >= {cfg.safe_recovery} MB, "
+                f"stopped: {[t['type']+':'+t['name'] for t in stopped_tiers]})"
             )
             last_log = now
 
         time.sleep(CHECK_INTERVAL_SECONDS)
         available_ram = get_available_memory_mb()
 
+    restored = [f"{t['type']}:{t['name']}" for t in reversed(stopped_tiers)]
     info(
         f"RAM recovered: {available_ram} MB (>= {cfg.safe_recovery} MB). "
-        f"Restoring services in reverse order: {list(reversed(stopped_names))}"
+        f"Restoring services in reverse order: {restored}"
     )
-    for name in reversed(stopped_names):
-        enable_monit_service(name, dry_run=cfg.dry_run)
+    for tier in reversed(stopped_tiers):
+        restore_tier(tier, dry_run=cfg.dry_run)
     if cfg.dry_run:
         info("[DRY-RUN] would clear state file.")
     else:
         clear_state()
 
-    info("Emergency recovery completed. Monit will restart the services.")
+    info("Emergency recovery completed.")
+    notify(
+        f"RAM recovered to {available_ram} MB. Services restored: {', '.join(restored)}.",
+        level="info",
+    )
 
 
 def main():
+    global _NOTIFY_SCRIPT, _NOTIFY_SERVER_NAME, _NOTIFY_LEVEL
+
     cfg = parse_args()
+    _NOTIFY_SCRIPT = cfg.notify_script
+    _NOTIFY_SERVER_NAME = cfg.server_name or os.uname().nodename
+    _NOTIFY_LEVEL = cfg.notify_level
 
     tier_summary = ", ".join(f"{t['type']}:{t['name']}" for t in cfg.tiers)
     mode = "DRY-RUN (no destructive actions will be taken)" if cfg.dry_run else "LIVE"
+    notify_status = "disabled" if not _NOTIFY_SCRIPT else f"enabled (level={_NOTIFY_LEVEL})"
     info(
         f"RAM Sentinel started [{mode}] | "
         f"Interval: {CHECK_INTERVAL_SECONDS}s | "
         f"Emergency Trigger: < {cfg.emergency_trigger} MB | "
         f"Safe Target: >= {cfg.safe_recovery} MB | "
-        f"Tiers: [{tier_summary}]"
+        f"Tiers: [{tier_summary}] | "
+        f"Notifications: {notify_status}"
     )
 
     try:
@@ -388,7 +456,6 @@ def main():
 
     validate_tiers(cfg.tiers)
 
-    # Resume an interrupted recovery (skipped in dry-run: state file is live-mode-only)
     if cfg.dry_run:
         info("[DRY-RUN] skipping state file load.")
     else:

--- a/monitoring/ram_sentinel/ram_sentinel_example.service
+++ b/monitoring/ram_sentinel/ram_sentinel_example.service
@@ -9,7 +9,10 @@ ExecStart=/usr/bin/python3 /usr/local/bin/ram_sentinel.py \
   --emergency-trigger 4000 \
   --safe-recovery 8000 \
   --tier kill:dhis_dev \
-  --tier stop:postgres
+  --tier stop:postgres \
+  --notify-script /path/to/notification_script.py \
+  --server-name my-server \
+  --notify-level critical
 Restart=always
 RestartSec=5
 SyslogIdentifier=stopramoom

--- a/monitoring/ram_sentinel/ram_sentinel_example.service
+++ b/monitoring/ram_sentinel/ram_sentinel_example.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Real-time RAM Protection Sentinel for Java and PostgreSQL
+Description=Real-time RAM Protection Sentinel
 After=network.target monit.service
 
 [Service]

--- a/monitoring/ram_sentinel/ram_sentinel_example.service
+++ b/monitoring/ram_sentinel/ram_sentinel_example.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Real-time RAM Protection Sentinel for Java and PostgreSQL
+After=network.target monit.service
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/python3 /usr/local/bin/ram_sentinel.py \
+  --emergency-trigger 4000 \
+  --safe-recovery 8000 \
+  --tier kill:dhis_dev \
+  --tier stop:postgres
+Restart=always
+RestartSec=5
+SyslogIdentifier=stopramoom
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION

📌 References
Issue: https://app.clickup.com/t/4528615/869e36g3p

📝 Implementation
  Adds `ram_sentinel.py`, a daemon that monitors available RAM and stops
  Monit-managed services when memory drops critically low, then restores
  them once RAM recovers. Configured per-environment via systemd ExecStart
  flags — no code changes needed between servers.

  Key design decisions:
  - Two stop strategies: `kill` (SIGKILL via Monit PID, for Java/Tomcat)
    and `stop` (clean monit stop, for Docker/Postgres)
  - Services stopped in tier order, restored in reverse
  - State persisted to /run/stopram/state.json so an interrupted recovery
    is resumed on daemon restart
  - `--dry-run` mode reads RAM and PIDs for real but skips all destructive
    commands

  ## How to install

  1. Copy `ram_sentinel.py` to `/usr/local/bin/ram_sentinel.py`
  2. Run a dry-run with the trigger set above current available RAM to
     force an emergency cycle and verify tier names and PID resolution:
     python3 /usr/local/bin/ram_sentinel.py
       --emergency-trigger <above_current_available_MB to test>
       --safe-recovery <target_MB>
       --tier kill:<monit_name>
       --dry-run
  3. Confirm output shows correct PID found and `[DRY-RUN] would...` for
  each action
  4. Create the appropriate `.service` file for the server to
     `/etc/systemd/system/ram-sentinel.service`
  5. Enable and start the service:
     systemctl daemon-reload && systemctl enable --now ram-sentinel
     journalctl -u ram-sentinel -f

